### PR TITLE
fix(notification): reconnect FCM listener after transport errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.16.3-beta.1] - 2026-05-03
+
+### Fixed
+- **FCM listener no longer reconnects after 3 sequential transport errors** — the upstream `firebase_messaging` client used to abort its receiver and never reconnect, leaving the doorbell camera black: `auto_on` answered `call_starting` but the push carrying the signaling payload never arrived (#3).
+  - `FcmPushClient` now uses `FcmPushClientConfig(abort_on_sequential_error_count=None)` so the library keeps retrying with its own backoff.
+  - A 60s watchdog (`async_track_time_interval`) revives the listener if `is_started` flips to False; `ensure_running()` is serialised by an `asyncio.Lock` so overlapping ticks cannot spawn parallel `FcmPushClient` instances.
+  - The notification grace period is intentionally not re-armed on revival — the existing `_processed_notifications` dedup deque already filters re-deliveries, and re-arming the blackout could drop a real doorbell ring landing during the window.
+
 ## [0.16.2] - 2026-04-23
 
 ### Fixed

--- a/custom_components/fermax_blue/__init__.py
+++ b/custom_components/fermax_blue/__init__.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 import logging
 import tempfile
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import voluptuous as vol
@@ -31,6 +31,7 @@ from .const import (
     DEFAULT_RECORDING_RETENTION,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    FCM_WATCHDOG_INTERVAL,
     PLATFORMS,
     RECORDINGS_DIR,
 )
@@ -238,6 +239,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: FermaxBlueConfigEntry) -
     from homeassistant.helpers.event import async_track_time_interval
 
     entry.async_on_unload(async_track_time_interval(hass, _cleanup_old_recordings, _td(hours=24)))
+
+    async def _fcm_watchdog(_now: datetime | None = None) -> None:
+        """Revive any FCM listener whose receiver has died."""
+        for coordinator in coordinators:
+            await coordinator.ensure_notifications_running()
+
+    entry.async_on_unload(
+        async_track_time_interval(hass, _fcm_watchdog, _td(seconds=FCM_WATCHDOG_INTERVAL))
+    )
 
     async def _async_shutdown(event: Event) -> None:
         """Clean up on shutdown."""

--- a/custom_components/fermax_blue/const.py
+++ b/custom_components/fermax_blue/const.py
@@ -63,3 +63,8 @@ CONF_SCAN_INTERVAL = "scan_interval"
 CONF_RECORDING_RETENTION = "recording_retention"
 DEFAULT_RECORDING_RETENTION = 10  # days
 RECORDINGS_DIR = "fermax_recordings"
+
+# Watchdog poll interval (seconds) for the FCM push receiver.
+# The upstream firebase_messaging client aborts the receiver after repeated
+# transport errors and never reconnects on its own; the watchdog revives it.
+FCM_WATCHDOG_INTERVAL = 60

--- a/custom_components/fermax_blue/coordinator.py
+++ b/custom_components/fermax_blue/coordinator.py
@@ -296,6 +296,24 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
                 )
             await self.notification_listener.stop()
 
+    async def ensure_notifications_running(self) -> None:
+        """Watchdog hook: revive the FCM listener if it died.
+
+        Re-deliveries of queued pushes after revival are filtered by the
+        ``_processed_notifications`` dedup deque, so we deliberately do NOT
+        re-arm the grace period — that would risk dropping a real doorbell ring
+        that lands during the blackout window.
+        """
+        if not self.notification_listener:
+            return
+        was_started = self.notification_listener.is_started
+        ok = await self.notification_listener.ensure_running()
+        if ok and not was_started:
+            _LOGGER.warning(
+                "FCM listener revived for device %s",
+                self.pairing.device_id,
+            )
+
     @callback
     def _handle_notification(self, notification: dict, persistent_id: str) -> None:
         """Handle an incoming FCM doorbell notification."""

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.1.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.16.2"
+  "version": "0.16.3-beta.1"
 }

--- a/custom_components/fermax_blue/notification.py
+++ b/custom_components/fermax_blue/notification.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Callable
 from typing import Any
 
-from firebase_messaging import FcmPushClient
+from firebase_messaging import FcmPushClient, FcmPushClientConfig
 from firebase_messaging.fcmregister import FcmRegister, FcmRegisterConfig
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
@@ -62,6 +63,7 @@ class FermaxNotificationListener:
             bundle_id=firebase_package_name,
         )
         self._store: Store = Store(hass, _FCM_STORAGE_VERSION, _FCM_STORAGE_KEY)
+        self._lifecycle_lock = asyncio.Lock()
 
     @property
     def fcm_token(self) -> str | None:
@@ -127,6 +129,11 @@ class FermaxNotificationListener:
 
     async def start(self) -> None:
         """Start listening for push notifications."""
+        async with self._lifecycle_lock:
+            await self._start_locked()
+
+    async def _start_locked(self) -> None:
+        """Inner ``start`` that assumes the lifecycle lock is already held."""
         if not self._credentials:
             await self.register()
 
@@ -139,6 +146,7 @@ class FermaxNotificationListener:
             fcm_config=self._fcm_config,
             credentials=self._credentials,
             credentials_updated_callback=self._on_credentials_updated,
+            config=FcmPushClientConfig(abort_on_sequential_error_count=None),
         )
 
         await self._push_client.start()
@@ -146,12 +154,50 @@ class FermaxNotificationListener:
 
     async def stop(self) -> None:
         """Stop listening for push notifications."""
-        if self._push_client:
-            await self._push_client.stop()
-            self._push_client = None
-            _LOGGER.info("FCM notification listener stopped")
+        async with self._lifecycle_lock:
+            if self._push_client:
+                await self._push_client.stop()
+                self._push_client = None
+                _LOGGER.info("FCM notification listener stopped")
 
     @property
     def is_started(self) -> bool:
         """Return True if the listener is running."""
         return self._push_client is not None and self._push_client.is_started()
+
+    async def ensure_running(self) -> bool:
+        """Reanimate the FCM listener if it has stopped.
+
+        The upstream client aborts the receiver after repeated transport errors
+        and never reconnects on its own. This method is meant to be polled by a
+        watchdog so the listener stays alive across network glitches.
+
+        Serialised via ``_lifecycle_lock`` so overlapping watchdog ticks cannot
+        spawn parallel ``FcmPushClient`` instances while a slow ``start()`` is
+        still handshaking.
+
+        Returns True when the listener is running after the call.
+        """
+        async with self._lifecycle_lock:
+            if self.is_started:
+                return True
+
+            if not self._credentials:
+                return False
+
+            _LOGGER.warning("FCM listener is not running; restarting it")
+            if self._push_client is not None:
+                try:
+                    await self._push_client.stop()
+                except (ConnectionError, OSError, RuntimeError) as err:
+                    _LOGGER.debug("Ignoring error during dead client teardown: %s", err)
+                self._push_client = None
+
+            # The persisted FCM token is reused, so the Fermax-side
+            # ``register_app_token`` mapping stays valid; no re-registration needed.
+            try:
+                await self._start_locked()
+            except (ConnectionError, OSError, RuntimeError):
+                _LOGGER.exception("Failed to restart FCM listener")
+                return False
+            return self.is_started

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -91,6 +91,8 @@ def coordinator(mock_hass, mock_api, pairing):
         coord._camera_timeout_unsub = None
         coord._dnd_enabled = None
         coord._last_opening = None
+        coord._notification_start_time = None
+        coord._processed_notifications = []
         coord.update_interval = None
     return coord
 
@@ -131,6 +133,58 @@ class TestCoordinatorCallGuard:
     async def test_call_guard_calls_api(self, coordinator, mock_api):
         await coordinator.call_guard()
         mock_api.call_guard.assert_called_once_with("dev1")
+
+
+class TestCoordinatorFcmWatchdog:
+    """Test the FCM listener watchdog hook."""
+
+    @pytest.mark.asyncio
+    async def test_no_listener_is_noop(self, coordinator):
+        coordinator.notification_listener = None
+        await coordinator.ensure_notifications_running()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_already_running_just_pings_listener(self, coordinator):
+        listener = MagicMock()
+        listener.is_started = True
+        listener.ensure_running = AsyncMock(return_value=True)
+        coordinator.notification_listener = listener
+        coordinator._notification_start_time = 12345.0  # any pre-existing value
+
+        await coordinator.ensure_notifications_running()
+
+        listener.ensure_running.assert_awaited_once()
+        # Watchdog must NOT touch the grace-period clock when nothing changed.
+        assert coordinator._notification_start_time == 12345.0
+
+    @pytest.mark.asyncio
+    async def test_revival_does_not_rearm_grace_period(self, coordinator):
+        """Dedup via _processed_notifications already filters re-deliveries.
+
+        Re-arming the grace period would silently drop a real doorbell ring
+        landing during the blackout window — see review B2.
+        """
+        listener = MagicMock()
+        listener.is_started = False
+        listener.ensure_running = AsyncMock(return_value=True)
+        coordinator.notification_listener = listener
+        coordinator._notification_start_time = None
+
+        await coordinator.ensure_notifications_running()
+
+        assert coordinator._notification_start_time is None
+
+    @pytest.mark.asyncio
+    async def test_revival_failure_keeps_grace_unchanged(self, coordinator):
+        listener = MagicMock()
+        listener.is_started = False
+        listener.ensure_running = AsyncMock(return_value=False)
+        coordinator.notification_listener = listener
+        coordinator._notification_start_time = None
+
+        await coordinator.ensure_notifications_running()
+
+        assert coordinator._notification_start_time is None
 
 
 class TestCoordinatorPhotoCaller:

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,0 +1,179 @@
+"""Tests for the FCM notification listener."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.fermax_blue.notification import FermaxNotificationListener
+
+
+@pytest.fixture
+def listener():
+    """Return a notification listener with credentials already populated."""
+    hass = MagicMock()
+    listener = FermaxNotificationListener(
+        hass=hass,
+        notification_callback=lambda *a, **kw: None,
+        firebase_api_key="key",
+        firebase_sender_id=1,
+        firebase_app_id="app",
+        firebase_project_id="proj",
+        firebase_package_name="com.fermax.blue.app",
+    )
+    listener._credentials = {"fcm": {"registration": {"token": "tok"}}}
+    return listener
+
+
+async def test_ensure_running_noop_when_already_started(listener):
+    """If the receiver is already running, ensure_running returns True without restarting."""
+    push_client = MagicMock()
+    push_client.is_started = MagicMock(return_value=True)
+    push_client.start = AsyncMock()
+    push_client.stop = AsyncMock()
+    listener._push_client = push_client
+
+    assert await listener.ensure_running() is True
+    push_client.start.assert_not_called()
+    push_client.stop.assert_not_called()
+
+
+async def test_ensure_running_revives_dead_listener(listener):
+    """A stopped receiver triggers stop+restart of the FCM client."""
+    dead_client = MagicMock()
+    dead_client.is_started = MagicMock(return_value=False)
+    dead_client.stop = AsyncMock()
+    listener._push_client = dead_client
+
+    new_client = MagicMock()
+    new_client.is_started = MagicMock(return_value=True)
+    new_client.start = AsyncMock()
+
+    with patch(
+        "custom_components.fermax_blue.notification.FcmPushClient",
+        return_value=new_client,
+    ) as fcm_cls:
+        ok = await listener.ensure_running()
+
+    assert ok is True
+    dead_client.stop.assert_awaited_once()
+    new_client.start.assert_awaited_once()
+    fcm_cls.assert_called_once()
+
+
+async def test_ensure_running_returns_false_without_credentials():
+    """Without credentials there is nothing the watchdog can do."""
+    hass = MagicMock()
+    listener = FermaxNotificationListener(
+        hass=hass,
+        notification_callback=lambda *a, **kw: None,
+        firebase_api_key="key",
+        firebase_sender_id=1,
+        firebase_app_id="app",
+        firebase_project_id="proj",
+        firebase_package_name="com.fermax.blue.app",
+    )
+
+    assert await listener.ensure_running() is False
+
+
+async def test_ensure_running_swallows_stop_errors(listener):
+    """A failure tearing down the dead client must not block restart."""
+    dead_client = MagicMock()
+    dead_client.is_started = MagicMock(return_value=False)
+    dead_client.stop = AsyncMock(side_effect=RuntimeError("already gone"))
+    listener._push_client = dead_client
+
+    new_client = MagicMock()
+    new_client.is_started = MagicMock(return_value=True)
+    new_client.start = AsyncMock()
+
+    with patch(
+        "custom_components.fermax_blue.notification.FcmPushClient",
+        return_value=new_client,
+    ):
+        assert await listener.ensure_running() is True
+
+    new_client.start.assert_awaited_once()
+
+
+async def test_ensure_running_returns_false_when_restart_fails(listener):
+    """If the restart blows up, the listener stays down and we report it."""
+    dead_client = MagicMock()
+    dead_client.is_started = MagicMock(return_value=False)
+    dead_client.stop = AsyncMock()
+    listener._push_client = dead_client
+
+    new_client = MagicMock()
+    new_client.is_started = MagicMock(return_value=False)
+    new_client.start = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch(
+        "custom_components.fermax_blue.notification.FcmPushClient",
+        return_value=new_client,
+    ):
+        assert await listener.ensure_running() is False
+
+
+async def test_start_passes_resilient_config(listener):
+    """The push client must be configured to keep retrying on transport errors."""
+    new_client = MagicMock()
+    new_client.start = AsyncMock()
+    new_client.is_started = MagicMock(return_value=True)
+
+    with patch(
+        "custom_components.fermax_blue.notification.FcmPushClient",
+        return_value=new_client,
+    ) as fcm_cls:
+        await listener.start()
+
+    kwargs = fcm_cls.call_args.kwargs
+    assert "config" in kwargs
+    assert kwargs["config"].abort_on_sequential_error_count is None
+
+
+async def test_concurrent_ensure_running_creates_one_client(listener):
+    """Overlapping watchdog ticks must NOT spawn parallel FcmPushClient instances.
+
+    Reproduces review finding B1: a slow ``start()`` could otherwise be racing
+    with a second tick that decides to ``stop()`` + restart again.
+    """
+    dead_client = MagicMock()
+    dead_client.is_started = MagicMock(return_value=False)
+    dead_client.stop = AsyncMock()
+    listener._push_client = dead_client
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    instances: list[MagicMock] = []
+
+    def _factory(*args, **kwargs):
+        client = MagicMock()
+        # Until release() is set, the client reports "not started" so
+        # an unguarded ensure_running() would mistake it for dead.
+        client.is_started = MagicMock(side_effect=lambda: release.is_set())
+        client.stop = AsyncMock()
+
+        async def _slow_start():
+            started.set()
+            await release.wait()
+
+        client.start = AsyncMock(side_effect=_slow_start)
+        instances.append(client)
+        return client
+
+    with patch(
+        "custom_components.fermax_blue.notification.FcmPushClient",
+        side_effect=_factory,
+    ):
+        first = asyncio.create_task(listener.ensure_running())
+        await started.wait()
+        # Second tick fires while the first ``start()`` is still handshaking.
+        second = asyncio.create_task(listener.ensure_running())
+        # Give the second task a chance to grab the lock (it should block).
+        await asyncio.sleep(0)
+        release.set()
+        results = await asyncio.gather(first, second)
+
+    assert results == [True, True]
+    assert len(instances) == 1, f"expected exactly one client, got {len(instances)}"


### PR DESCRIPTION
## Summary

- Construct `FcmPushClient` with `FcmPushClientConfig(abort_on_sequential_error_count=None)` so the upstream library keeps retrying with its own backoff instead of giving up after 3 sequential connection errors.
- Add a 60s watchdog (`async_track_time_interval`) that revives the FCM listener if `is_started` flips to False. `ensure_running()` is serialised by an `asyncio.Lock` so overlapping watchdog ticks cannot spawn parallel `FcmPushClient` instances while a slow `start()` is still handshaking.
- Deliberately do **not** re-arm the notification grace period on revival: re-deliveries are already filtered by the `_processed_notifications` dedup deque, and re-arming the 10s blackout could drop a real doorbell ring landing during the window.

## Why

In production HA, after `firebase_messaging` shut down the receiver due to 3 sequential `CONNECTION` errors, the listener stayed dead for 48+ hours. The doorbell button still answered `auto_on → call_starting`, but no FCM push ever returned with the signaling payload, so the camera went black. See issue #3 for the full diagnosis and the actual log lines.

## Test plan

- [x] `make check` (Python 3.12): lint + ruff format + mypy + vulture + 134 tests, all green
- [x] New unit tests: noop when already running, revival from dead state, missing-credentials short-circuit, swallowed teardown errors, restart-failure path, resilient-config kwarg, **concurrent revival produces exactly one `FcmPushClient` instance** (regression test for the watchdog race)
- [x] New coordinator tests: watchdog noop with no listener, no grace re-arm on success or failure
- [x] CI matrix (Python 3.12 + 3.13) — local 3.13 build blocked by Docker Hub r2 backend timeouts; relying on GitHub Actions to validate 3.13
- [ ] Live verification on production HA: deploy branch, reproduce listener shutdown via network glitch, confirm watchdog revives within 60s and camera preview returns video

Related to #3