### PR TITLE
chore(release): v0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.16.3-beta.1] - 2026-05-03
+## [0.16.3] - 2026-05-04
 
 ### Fixed
 - **FCM listener no longer reconnects after 3 sequential transport errors** — the upstream `firebase_messaging` client used to abort its receiver and never reconnect, leaving the doorbell camera black: `auto_on` answered `call_starting` but the push carrying the signaling payload never arrived (#3).

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.1.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.16.3-beta.1"
+  "version": "0.16.3"
 }


### PR DESCRIPTION
## Summary

Promotes [`v0.16.3-beta.1`](https://github.com/bvis/fermax-blue-hass/releases/tag/v0.16.3-beta.1) to stable.

After ~24 h running the beta on a production HA instance:
- Zero `Shutting down push receiver due to N sequential errors` log lines (the regression that motivated the fix).
- Three clean self-reconnects from the underlying `firebase_messaging` client — exactly the behaviour expected from `abort_on_sequential_error_count=None`.
- Zero watchdog revivals — the listener never had to be reanimated, since the library now reconnects on its own.
- Camera preview verified end-to-end (button → `call_starting` → FCM signaling push → mediasoup room joined → live frames → clean stop).

## Test plan

- [x] `make pre-push` (Python 3.12 + 3.13): 134 tests, lint, format, mypy, vulture all green
- [x] CI matrix on the originating PR (#4) was green
- [x] 24 h soak on production HA — see metrics above
- [ ] CI matrix re-validates this branch

Related to #3