### PR TITLE
chore(release): v0.16.4-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.16.4-beta.1] - 2026-06-11
+
+### Fixed
+- **Config flow could not render on recent Home Assistant versions** (#8, #9, #10, #11) — the credentials form schema used a custom callable HTTPS validator that `voluptuous_serialize` cannot convert (`ValueError: Unable to convert schema: <function _https_url ...>`), blocking login entirely. URL fields are now plain strings in the form schema and HTTPS validation runs after submit, returning a translated `invalid_url` error (all 10 languages). Contributed by @pespinel (#7).
+- **OAuth authentication diagnostics** — non-JSON responses, HTTP errors, OAuth error payloads, and missing `access_token` are now handled explicitly with safe, redacted log messages; `invalid_client` errors point to the OAuth Basic header instead of the user's email/password (#7).
+- **APK credential extraction** — `scripts/extract_credentials.py` ignores unrelated `Basic` headers from tracing/telemetry code and generates the OAuth header from `OAuthUtils.java` + `Urls.clientId()`/`Urls.clientSecret()`, detecting the production environment; extracted secrets are redacted in console output (#7).
+
 ## [0.16.3] - 2026-05-04
 
 ### Fixed

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.1.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.16.3"
+  "version": "0.16.4-beta.1"
 }


### PR DESCRIPTION
## Summary

Beta release for the config flow fix merged in #7.

- Bump `manifest.json` version to `0.16.4-beta.1`
- Add CHANGELOG entry covering #7 (fixes #8, #9, #10, #11)

## Tests

`make pre-push` passed locally (lint, format, mypy, 138 tests on Python 3.12 + 3.13).

After merge: tag `v0.16.4-beta.1` and publish a GitHub pre-release.