### PR TITLE
fix: FCM watchdog observability — demote spurious WARNING, log swallowed restart errors (v0.16.5-beta.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.16.5-beta.1] - 2026-06-12
+
+### Fixed
+- **FCM watchdog observability** (#16) — follow-up to the reconnect-storm hardening in 0.16.4, no behavior changes to the restart state machine:
+  - The "FCM listener is not running; restart scheduled" message is now logged at INFO instead of WARNING. `is_started()` is also False during seconds-long transient states (socket resets, initial connection), so a watchdog tick landing inside one produced a recurring, alarming WARNING that the next healthy tick silently cleared. WARNING is now reserved for the restart actually firing.
+  - `ensure_running()` catches all exceptions around the restart (not just connection errors) and logs them with traceback. Previously, errors raised by the `register()` path (e.g. HTTP or validation errors) escaped the catch and were silently discarded by the watchdog's `return_exceptions=True` gather — a failed restart attempt left no log line at all.
+  - `ensure_running()` now returns the success of the start call instead of `is_started` (which is usually still False while the freshly restarted client is connecting), matching its documented contract.
+  - The traceback rate-limit filter no longer consumes throttle budget on records carrying `exc_info=(None, None, None)` (produced by `exc_info=True` outside an `except` block) — such records have no traceback to strip and now pass through untouched.
+
 ## [0.16.4] - 2026-06-11
 
 ### Fixed

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.1.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.16.4"
+  "version": "0.16.5-beta.1"
 }

--- a/custom_components/fermax_blue/notification.py
+++ b/custom_components/fermax_blue/notification.py
@@ -56,7 +56,9 @@ class _FcmExcInfoRateLimitFilter(logging.Filter):
         self._timestamps: deque[float] = deque()
 
     def filter(self, record: logging.LogRecord) -> bool:
-        if not record.exc_info:
+        # exc_info=True outside an except block yields the truthy (None, None,
+        # None) tuple — no traceback to strip, so it must not consume budget.
+        if not record.exc_info or record.exc_info[0] is None:
             return True
 
         now = time.monotonic()
@@ -247,7 +249,8 @@ class FermaxNotificationListener:
         ``_lifecycle_lock`` so overlapping ticks cannot spawn parallel
         ``FcmPushClient`` instances.
 
-        Returns True when the listener is running after the call.
+        Returns True when the listener is running, or when a restart attempt
+        was successfully initiated (the client may still be connecting).
         """
         if self.is_started:
             self._restart_backoff = FCM_RESTART_BACKOFF_INITIAL
@@ -264,8 +267,13 @@ class FermaxNotificationListener:
             now = time.monotonic()
             if self._restart_at is None:
                 self._restart_at = now + self._restart_backoff
-                _LOGGER.warning(
-                    "FCM listener is not running; restart scheduled in %.0f seconds",
+                # INFO, not WARNING: is_started() is also False during
+                # seconds-long transient states (RESETTING, STARTING_*), and a
+                # healthy next tick clears this schedule silently. WARNING is
+                # reserved for the restart actually firing below.
+                _LOGGER.info(
+                    "FCM listener is not running; restart scheduled in %.0f seconds "
+                    "(cleared automatically if the listener recovers on its own)",
                     self._restart_backoff,
                 )
                 return False
@@ -284,7 +292,13 @@ class FermaxNotificationListener:
 
             try:
                 await self._start_locked()
-            except (ConnectionError, OSError, RuntimeError):
+            except Exception:
+                # Catch everything: the register() path can raise types beyond
+                # connection errors, and the watchdog gathers with
+                # return_exceptions=True and discards results — anything
+                # escaping here would be swallowed with no log line at all.
                 _LOGGER.exception("Failed to restart FCM listener")
                 return False
-            return self.is_started
+            # The client is usually still connecting (STARTING_*) here, so
+            # report the success of the start call rather than is_started.
+            return True

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -273,6 +273,74 @@ async def test_healthy_observation_resets_backoff(listener):
     assert listener._restart_at is None
 
 
+async def test_transient_reset_window_emits_no_warning(listener, caplog):
+    """A tick landing inside a routine reset window must not alarm the operator.
+
+    ``is_started()`` is also False during seconds-long transient states
+    (RESETTING, STARTING_*); scheduling the restart must stay below WARNING,
+    and the next healthy tick must clear the schedule without restarting.
+    """
+    client = _dead_client()
+    listener._push_client = client
+    clock = _FakeClock()
+
+    with (
+        patch("custom_components.fermax_blue.notification.time", clock),
+        patch("custom_components.fermax_blue.notification.FcmPushClient") as fcm_cls,
+        caplog.at_level(logging.DEBUG, logger="custom_components.fermax_blue.notification"),
+    ):
+        assert await listener.ensure_running() is False  # tick inside the reset window
+        client.is_started.return_value = True  # client recovered on its own
+        assert await listener.ensure_running() is True
+
+    fcm_cls.assert_not_called()
+    assert listener._restart_at is None
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+async def test_ensure_running_logs_unexpected_restart_errors(listener, caplog):
+    """Restart failures outside the connection-error family must not vanish.
+
+    The watchdog gathers with ``return_exceptions=True`` and discards results,
+    so anything escaping this catch is swallowed with no log line at all.
+    """
+    listener._push_client = _dead_client()
+    listener._restart_at = 0.0  # backoff deadline already elapsed
+
+    new_client = _dead_client()
+    new_client.start = AsyncMock(side_effect=ValueError("bad registration payload"))
+
+    with (
+        patch(
+            "custom_components.fermax_blue.notification.FcmPushClient",
+            return_value=new_client,
+        ),
+        caplog.at_level(logging.ERROR, logger="custom_components.fermax_blue.notification"),
+    ):
+        assert await listener.ensure_running() is False
+
+    assert any(
+        r.exc_info and "Failed to restart FCM listener" in r.getMessage() for r in caplog.records
+    )
+
+
+async def test_ensure_running_returns_true_while_restarted_client_connects(listener):
+    """A successful restart returns True even though the client is still in STARTING_*."""
+    listener._push_client = _dead_client()
+    listener._restart_at = 0.0  # backoff deadline already elapsed
+
+    connecting_client = _dead_client()  # is_started stays False while connecting
+    connecting_client.start = AsyncMock()
+
+    with patch(
+        "custom_components.fermax_blue.notification.FcmPushClient",
+        return_value=connecting_client,
+    ):
+        assert await listener.ensure_running() is True
+
+    connecting_client.start.assert_awaited_once()
+
+
 async def test_start_installs_exc_rate_limit_filter_once(listener):
     """start() attaches the rate-limit filter to the upstream logger exactly once."""
     upstream = logging.getLogger(FCM_UPSTREAM_LOGGER)
@@ -328,6 +396,34 @@ def test_exc_filter_allows_tracebacks_again_after_window():
         record = _exc_record()
         assert log_filter.filter(record) is True
         assert record.exc_info is not None
+
+
+def test_exc_filter_ignores_none_exc_info_tuple():
+    """exc_info=(None, None, None) carries no traceback and must pass untouched.
+
+    ``logging`` produces this truthy tuple for ``exc_info=True`` outside an
+    ``except`` block; it must not consume throttle budget or gain the
+    "suppressed" suffix.
+    """
+    clock = _FakeClock()
+    with patch("custom_components.fermax_blue.notification.time", clock):
+        log_filter = _FcmExcInfoRateLimitFilter()
+        record = logging.LogRecord(
+            FCM_UPSTREAM_LOGGER,
+            logging.ERROR,
+            __file__,
+            1,
+            "no traceback",
+            None,
+            (None, None, None),
+        )
+        assert log_filter.filter(record) is True
+        assert record.getMessage() == "no traceback"
+
+        # The full traceback budget must still be available afterwards.
+        real_records = [_exc_record() for _ in range(FCM_EXC_LOG_LIMIT)]
+        assert all(log_filter.filter(r) for r in real_records)
+        assert all(r.exc_info for r in real_records)
 
 
 def test_exc_filter_ignores_records_without_exc_info():


### PR DESCRIPTION
Closes #16. Observability follow-up to the FCM reconnect-storm hardening shipped in #14 (v0.16.4-beta.2). The restart state machine is unchanged.

## Changes

- **Demote the spurious scheduling WARNING to INFO.** `is_started()` is also `False` during seconds-long transient states (`RESETTING`, `STARTING_*` — e.g. routine upstream socket resets), so a 60 s watchdog tick landing inside one logged a recurring, alarming `WARNING: FCM listener is not running; restart scheduled…` that the next healthy tick silently cleared. WARNING is now reserved for the moment the restart actually fires. Scheduling is intentionally **not** gated on transient run states: a client stuck in `STARTING_CONNECTION` after exhausting initial retries (zombie mode) must stay visible to the watchdog.
- **Stop swallowing restart exceptions.** `ensure_running()` caught only `(ConnectionError, OSError, RuntimeError)`, but the `register()` path can raise other types; combined with the watchdog's `return_exceptions=True` gather discarding results, a failed restart attempt left no log line at all. The catch is now `Exception` with `_LOGGER.exception(...)`.
- **Fix the return-value contract.** `ensure_running()` returned `is_started` right after a successful restart, which is usually `False` while the fresh client is still connecting — contradicting the docstring. It now returns the success of the start call.
- **Rate-limit filter nit.** `exc_info == (None, None, None)` (a truthy tuple, produced by `exc_info=True` outside an `except` block) no longer consumes throttle budget nor gains the "(traceback suppressed)" suffix.

## Tests

4 new tests (18 total in `test_notification.py`, 154 overall):

- Tick inside a transient reset window → no WARNING-level record, no restart, schedule cleared by the next healthy tick (the only path of the state machine that lacked coverage).
- Unexpected restart exception (`ValueError`) → returns `False`, logged with traceback, not propagated.
- Successful restart while the client is still connecting → returns `True`.
- `exc_info=(None, None, None)` record → passes untouched, budget intact.

## Release

Version bumped to **0.16.5-beta.1** per the beta-first release workflow; promote to 0.16.5 stable after verifying on live HA.

`make pre-push` (full CI replica, py3.12 + py3.13) passes.