### PR TITLE
fix(security): validate signaling URL + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies

--- a/custom_components/fermax_blue/coordinator.py
+++ b/custom_components/fermax_blue/coordinator.py
@@ -10,6 +10,7 @@ from dataclasses import replace
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -47,6 +48,17 @@ CAMERA_TIMEOUT_SECONDS = 90
 # FCM re-delivers recent notifications when the listener reconnects after a
 # reload/restart, causing phantom doorbell rings. Ignore them briefly.
 NOTIFICATION_GRACE_PERIOD = 10
+ALLOWED_SIGNALING_DOMAIN = ".fermax.io"
+
+
+def _is_trusted_signaling_url(url: str) -> bool:
+    """Reject signaling URLs outside known Fermax domains."""
+    try:
+        parsed = urlparse(url)
+        host = (parsed.hostname or "").lower()
+        return host.endswith(ALLOWED_SIGNALING_DOMAIN) or host == "fermax.io"
+    except ValueError:
+        return False
 
 
 class FermaxBlueCoordinator(DataUpdateCoordinator):
@@ -349,6 +361,12 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
         )
         if should_stream:
             socket_url = data.get("SocketUrl", DEFAULT_SIGNALING_URL)
+            if not _is_trusted_signaling_url(socket_url):
+                _LOGGER.warning(
+                    "Rejected untrusted signaling URL from notification: %s",
+                    socket_url,
+                )
+                socket_url = DEFAULT_SIGNALING_URL
             fermax_token = data.get("FermaxToken", "")
             self.hass.async_create_task(self._start_stream(room_id, socket_url, fermax_token))
             if (

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,7 +10,10 @@ from custom_components.fermax_blue.api import (
     FermaxBlueApi,
     Pairing,
 )
-from custom_components.fermax_blue.coordinator import FermaxBlueCoordinator
+from custom_components.fermax_blue.coordinator import (
+    FermaxBlueCoordinator,
+    _is_trusted_signaling_url,
+)
 
 
 @pytest.fixture
@@ -198,3 +201,33 @@ class TestCoordinatorScanInterval:
             FermaxBlueCoordinator(mock_hass, mock_api, pairing, scan_interval=10)
             call_kwargs = mock_init.call_args
             assert call_kwargs.kwargs["update_interval"].total_seconds() == 600
+
+
+class TestSignalingUrlValidation:
+    """Test signaling URL domain validation."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://signaling-pro-duoxme.fermax.io",
+            "https://signaling.fermax.io/path",
+            "wss://signaling-pro-duoxme.fermax.io",
+            "https://fermax.io",
+        ],
+    )
+    def test_trusted_urls_accepted(self, url):
+        assert _is_trusted_signaling_url(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://evil.com",
+            "https://notfermax.io",
+            "https://fermax.io.evil.com",
+            "https://evil-fermax.io",
+            "",
+            "not-a-url",
+        ],
+    )
+    def test_untrusted_urls_rejected(self, url):
+        assert _is_trusted_signaling_url(url) is False


### PR DESCRIPTION
## Summary

- **Validate signaling URL domain from FCM notifications** — The `SocketUrl` field in FCM push notifications was used directly without domain validation. If FCM delivery were compromised, an attacker could redirect the WebSocket connection to a malicious signaling server, capturing OAuth and FCM tokens. Now validates against `*.fermax.io` and falls back to `DEFAULT_SIGNALING_URL` for untrusted URLs.
- **Add Dependabot** — Enables weekly automated dependency scanning for pip packages and GitHub Actions to catch vulnerabilities in runtime dependencies (Pillow, firebase-messaging, pymediasoup, etc.).

## Test plan

- [x] All 160 existing tests pass
- [x] 10 new parametrized tests for URL validation (trusted + untrusted URLs, subdomain spoofing, empty/garbage input)
- [x] Lint, format, type-check, dead-code analysis all clean (`make check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)