### PR TITLE
chore(release): v0.16.5-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.16.5-beta.2] - 2026-06-12
+
+### Fixed
+- **Signaling URL domain validation** — the `SocketUrl` delivered in FCM push notifications was used directly to open the WebSocket signaling connection. A compromised or spoofed push could redirect the connection to an attacker-controlled signaling server, exposing OAuth and FCM tokens. Signaling URLs are now validated against `*.fermax.io` (covers all known Fermax environments: pro, devel, staging, SIS); untrusted URLs are logged and replaced with the default signaling URL. Contributed by @aitoraznar (#18).
+
+### Added
+- **Dependabot** — weekly automated dependency update PRs for the Python dev toolchain and GitHub Actions (#18).
+
 ## [0.16.5-beta.1] - 2026-06-12
 
 ### Fixed

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.1.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.16.5-beta.1"
+  "version": "0.16.5-beta.2"
 }


### PR DESCRIPTION
Version bump to **0.16.5-beta.2** after merging #18, plus the corresponding CHANGELOG entries:

- **Fixed**: signaling URL domain validation (`*.fermax.io` allowlist, untrusted URLs fall back to the default) — contributed by @aitoraznar (#18).
- **Added**: Dependabot weekly scanning for the Python dev toolchain and GitHub Actions (#18).

This beta now bundles #17 (FCM watchdog observability) and #18. Next steps per the release workflow: tag `v0.16.5-beta.2`, deploy and verify on live HA, then promote to 0.16.5 stable.

`make pre-push` (full CI replica, py3.12 + py3.13, 164 tests) passes.