### PR TITLE
chore(release): v0.16.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,17 @@
 # Changelog
 
-## [0.16.5-beta.2] - 2026-06-12
+## [0.16.5] - 2026-06-15
 
 ### Fixed
 - **Signaling URL domain validation** — the `SocketUrl` delivered in FCM push notifications was used directly to open the WebSocket signaling connection. A compromised or spoofed push could redirect the connection to an attacker-controlled signaling server, exposing OAuth and FCM tokens. Signaling URLs are now validated against `*.fermax.io` (covers all known Fermax environments: pro, devel, staging, SIS); untrusted URLs are logged and replaced with the default signaling URL. Contributed by @aitoraznar (#18).
-
-### Added
-- **Dependabot** — weekly automated dependency update PRs for the Python dev toolchain and GitHub Actions (#18).
-
-## [0.16.5-beta.1] - 2026-06-12
-
-### Fixed
 - **FCM watchdog observability** (#16) — follow-up to the reconnect-storm hardening in 0.16.4, no behavior changes to the restart state machine:
   - The "FCM listener is not running; restart scheduled" message is now logged at INFO instead of WARNING. `is_started()` is also False during seconds-long transient states (socket resets, initial connection), so a watchdog tick landing inside one produced a recurring, alarming WARNING that the next healthy tick silently cleared. WARNING is now reserved for the restart actually firing.
   - `ensure_running()` catches all exceptions around the restart (not just connection errors) and logs them with traceback. Previously, errors raised by the `register()` path (e.g. HTTP or validation errors) escaped the catch and were silently discarded by the watchdog's `return_exceptions=True` gather — a failed restart attempt left no log line at all.
   - `ensure_running()` now returns the success of the start call instead of `is_started` (which is usually still False while the freshly restarted client is connecting), matching its documented contract.
   - The traceback rate-limit filter no longer consumes throttle budget on records carrying `exc_info=(None, None, None)` (produced by `exc_info=True` outside an `except` block) — such records have no traceback to strip and now pass through untouched.
+
+### Added
+- **Dependabot** — weekly automated dependency update PRs for the Python dev toolchain and GitHub Actions (#18).
 
 ## [0.16.4] - 2026-06-11
 

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.1.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.16.5-beta.2"
+  "version": "0.16.5"
 }


### PR DESCRIPTION
Promotes `v0.16.5-beta.2` to stable `v0.16.5`.

Bumps `manifest.json` to `0.16.5` and collapses the beta CHANGELOG entries (beta.1 + beta.2) into a single `## [0.16.5]` section.

### Included since v0.16.4
**Fixed**
- Signaling URL domain validation against `*.fermax.io` — prevents spoofed FCM push from redirecting signaling to an attacker server (#18, @aitoraznar).
- FCM watchdog observability — demote spurious WARNING, log swallowed restart errors, correct `ensure_running()` return contract (#16).

**Added**
- Dependabot — weekly dependency update PRs (#18).

No code changes in this PR beyond the version bump + changelog. `make pre-push` green (lint, format, typecheck, 164 tests on 3.12 + 3.13).