### PR TITLE
fix(notification): pad FCM crypto-key/salt headers to survive malformed pushes (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **FCM client no longer shuts down on a malformed push** (#21) — some Fermax FCM data messages carry a `crypto-key`/`encryption` header whose base64 value is not a multiple of 4. Upstream `firebase-messaging` pads the stored key material before decoding but not these per-message headers, so `urlsafe_b64decode` raised `binascii.Error: Incorrect padding` inside the `_listen` loop; the library's catch-all then shut the whole `FcmPushClient` down, taking push notifications offline until the watchdog restarted it (and re-killing it if the message was redelivered). The integration now right-pads both headers before the upstream decrypt runs, so the affected messages decrypt normally instead of crashing the listener.
+
 ## [0.16.5] - 2026-06-15
 
 ### Fixed

--- a/custom_components/fermax_blue/notification.py
+++ b/custom_components/fermax_blue/notification.py
@@ -83,6 +83,44 @@ def _install_fcm_log_rate_limit() -> None:
         upstream.addFilter(_FcmExcInfoRateLimitFilter())
 
 
+def _b64_pad(value: str) -> str:
+    """Right-pad a urlsafe base64 string with '=' to a length multiple of 4."""
+    return value + "=" * (-len(value) % 4)
+
+
+def _patch_fcm_crypto_key_padding() -> None:
+    """Make firebase_messaging tolerant of unpadded crypto-key/encryption headers.
+
+    Upstream ``FcmPushClient._decrypt_raw_data`` pads the stored ``private`` and
+    ``secret`` keys before base64-decoding them, but NOT the per-message
+    ``crypto-key`` (dh=) and ``encryption`` (salt=) headers. Some FCM data
+    messages carry header values whose base64 length is not a multiple of 4, so
+    ``urlsafe_b64decode`` raises ``binascii.Error: Incorrect padding`` inside the
+    ``_listen`` loop. The upstream catch-all treats that as an unknown error and
+    shuts the whole client down, taking push notifications offline (issue #21).
+
+    Right-pad both headers before delegating to the original implementation; the
+    padding is deterministic from the string length, so a correctly-padded value
+    is passed through unchanged. Idempotent: safe to call on every (re)start.
+    """
+    original = FcmPushClient._decrypt_raw_data
+    if getattr(original, "_fermax_padding_patched", False):
+        return
+
+    def _decrypt_raw_data_padded(
+        credentials: dict[str, dict[str, str]],
+        crypto_key_str: str,
+        salt_str: str,
+        raw_data: bytes,
+    ) -> bytes:
+        return original(credentials, _b64_pad(crypto_key_str), _b64_pad(salt_str), raw_data)
+
+    _decrypt_raw_data_padded._fermax_padding_patched = True  # type: ignore[attr-defined]
+    FcmPushClient._decrypt_raw_data = staticmethod(  # type: ignore[assignment]
+        _decrypt_raw_data_padded
+    )
+
+
 _SENSITIVE_LOG_KEYS = frozenset(
     {"FermaxToken", "fermaxOauthToken", "appToken", "token", "fcm_token"}
 )
@@ -208,6 +246,7 @@ class FermaxNotificationListener:
             return
 
         _install_fcm_log_rate_limit()
+        _patch_fcm_crypto_key_padding()
 
         # Bounded abort: let the upstream client give up after a few sequential
         # errors instead of spinning forever on a poisoned reader; the watchdog

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,10 +1,14 @@
 """Tests for the FCM notification listener."""
 
 import asyncio
+import binascii
+import inspect
 import logging
+from base64 import urlsafe_b64decode
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from firebase_messaging.fcmpushclient import FcmPushClient
 
 from custom_components.fermax_blue.notification import (
     FCM_ABORT_SEQUENTIAL_ERROR_COUNT,
@@ -14,7 +18,9 @@ from custom_components.fermax_blue.notification import (
     FCM_RESTART_BACKOFF_MAX,
     FCM_UPSTREAM_LOGGER,
     FermaxNotificationListener,
+    _b64_pad,
     _FcmExcInfoRateLimitFilter,
+    _patch_fcm_crypto_key_padding,
 )
 
 
@@ -439,3 +445,70 @@ def test_exc_filter_ignores_records_without_exc_info():
         )
         assert log_filter.filter(record) is True
         assert record.getMessage() == "plain message"
+
+
+@pytest.fixture
+def restore_fcm_decrypt():
+    """Restore FcmPushClient._decrypt_raw_data after a test mutates it via the patch."""
+    original = inspect.getattr_static(FcmPushClient, "_decrypt_raw_data")
+    yield
+    FcmPushClient._decrypt_raw_data = original
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("A" * 86, "A" * 86 + "=="),  # len % 4 == 2
+        ("A" * 87, "A" * 87 + "="),  # len % 4 == 3
+        ("A" * 88, "A" * 88),  # already a multiple of 4 -> unchanged
+        ("", ""),
+    ],
+)
+def test_b64_pad_normalises_length_to_multiple_of_four(value, expected):
+    padded = _b64_pad(value)
+    assert padded == expected
+    assert len(padded) % 4 == 0
+
+
+def test_b64_pad_makes_incorrect_padding_value_decodable():
+    """An 'Incorrect padding' base64 value becomes decodable after padding (issue #21)."""
+    unpadded = "A" * 86  # len % 4 == 2 -> urlsafe_b64decode raises Incorrect padding
+    with pytest.raises(binascii.Error):
+        urlsafe_b64decode(unpadded.encode("ascii"))
+    # Must not raise after padding.
+    urlsafe_b64decode(_b64_pad(unpadded).encode("ascii"))
+
+
+def test_patch_pads_crypto_key_and_salt_before_delegating(restore_fcm_decrypt):
+    """The patch right-pads the crypto-key/encryption headers before handing them
+    to the upstream decrypter, so an unpadded header no longer raises
+    binascii.Error in the listen loop and shuts the client down (issue #21)."""
+    received: dict[str, str] = {}
+
+    def _spy(credentials, crypto_key_str, salt_str, raw_data):
+        received["crypto_key"] = crypto_key_str
+        received["salt"] = salt_str
+        return b"decrypted"
+
+    FcmPushClient._decrypt_raw_data = staticmethod(_spy)
+    _patch_fcm_crypto_key_padding()
+
+    result = FcmPushClient._decrypt_raw_data({}, "A" * 86, "B" * 87, b"raw")
+
+    assert result == b"decrypted"
+    assert received["crypto_key"] == "A" * 86 + "=="
+    assert received["salt"] == "B" * 87 + "="
+    assert len(received["crypto_key"]) % 4 == 0
+    assert len(received["salt"]) % 4 == 0
+
+
+def test_patch_is_idempotent(restore_fcm_decrypt):
+    """Calling the patch twice does not re-wrap _decrypt_raw_data."""
+    FcmPushClient._decrypt_raw_data = staticmethod(
+        lambda credentials, crypto_key_str, salt_str, raw_data: b""
+    )
+    _patch_fcm_crypto_key_padding()
+    first = inspect.getattr_static(FcmPushClient, "_decrypt_raw_data")
+    _patch_fcm_crypto_key_padding()
+    second = inspect.getattr_static(FcmPushClient, "_decrypt_raw_data")
+    assert first is second


### PR DESCRIPTION
## Summary

Fixes #21. Some Fermax FCM data messages carry a `crypto-key` (dh=) / `encryption` (salt=) header whose base64 value is not a multiple of 4. Upstream `firebase-messaging` pads the stored `private`/`secret` key material before base64-decoding it, **but not these per-message headers**, so `urlsafe_b64decode` raises `binascii.Error: Incorrect padding` inside the `_listen` loop:

```
ERROR ... [firebase_messaging.fcmpushclient] Unknown error: Incorrect padding, shutting down FcmPushClient.
  ...
  File ".../fcmpushclient.py", line 378, in _decrypt_raw_data
    crypto_key = urlsafe_b64decode(crypto_key_str.encode("ascii"))
binascii.Error: Incorrect padding
```

The library's catch-all treats this as an unknown error and **shuts the whole `FcmPushClient` down**, taking push notifications offline until the watchdog restarts it — and re-killing it if the offending message is redelivered.

## Fix

An idempotent monkeypatch of `FcmPushClient._decrypt_raw_data` right-pads both headers (`_b64_pad`, deterministic from string length) before delegating to the original implementation, so the affected messages decrypt normally instead of crashing the listener. Correctly-padded values pass through unchanged. Same pattern already used for `_patch_pymediasoup_audio_channels` in `streaming.py`; installed on every (re)start alongside `_install_fcm_log_rate_limit()`.

Note: only base64 lengths `% 4 ∈ {2, 3}` produce the recoverable "Incorrect padding" case this targets; `% 4 == 1` is structurally invalid base64 and raises a different error (out of scope, not observed in the report).

## Tests

7 new tests (TDD, red→green): `_b64_pad` normalisation, that an "Incorrect padding" value becomes decodable, that the patch pads crypto-key and salt before delegating, and that it is idempotent.

`make pre-push` green: ruff + format + mypy + vulture clean, **171 tests pass on Python 3.12 and 3.13**.

## CHANGELOG

Added a temporary `## [Unreleased]` entry — to be consolidated into the versioned (beta) entry at release time.