### PR TITLE
chore(release): v0.16.6-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.16.6-beta.1] - 2026-06-17
 
 ### Fixed
 - **FCM client no longer shuts down on a malformed push** (#21) — some Fermax FCM data messages carry a `crypto-key`/`encryption` header whose base64 value is not a multiple of 4. Upstream `firebase-messaging` pads the stored key material before decoding but not these per-message headers, so `urlsafe_b64decode` raised `binascii.Error: Incorrect padding` inside the `_listen` loop; the library's catch-all then shut the whole `FcmPushClient` down, taking push notifications offline until the watchdog restarted it (and re-killing it if the message was redelivered). The integration now right-pads both headers before the upstream decrypt runs, so the affected messages decrypt normally instead of crashing the listener.

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.1.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.16.5"
+  "version": "0.16.6-beta.1"
 }


### PR DESCRIPTION
Beta prerelease bundling the FCM `Incorrect padding` fix (#21, PR #23).

- Bump `manifest.json` to `0.16.6-beta.1`.
- Promote the temporary `## [Unreleased]` CHANGELOG entry to `## [0.16.6-beta.1]`.

To be deployed to the live HA and verified before promotion to `0.16.6` stable.