### PR TITLE
chore(release): v0.16.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.16.6-beta.1] - 2026-06-17
+## [0.16.6] - 2026-06-18
 
 ### Fixed
 - **FCM client no longer shuts down on a malformed push** (#21) — some Fermax FCM data messages carry a `crypto-key`/`encryption` header whose base64 value is not a multiple of 4. Upstream `firebase-messaging` pads the stored key material before decoding but not these per-message headers, so `urlsafe_b64decode` raised `binascii.Error: Incorrect padding` inside the `_listen` loop; the library's catch-all then shut the whole `FcmPushClient` down, taking push notifications offline until the watchdog restarted it (and re-killing it if the message was redelivered). The integration now right-pads both headers before the upstream decrypt runs, so the affected messages decrypt normally instead of crashing the listener.

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.1.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.16.6-beta.1"
+  "version": "0.16.6"
 }


### PR DESCRIPTION
Promote 0.16.6-beta.1 → **0.16.6** stable.

The FCM `Incorrect padding` fix (#21) is confirmed working in the wild by the reporter on the beta, and verified end-to-end (no regression) on a live instance.

- Bump `manifest.json` to `0.16.6`.
- Consolidate the beta CHANGELOG entry into `## [0.16.6]`.

Note: the separate FCM connectivity issue (#25) and the streaming symptom downstream of it (#22) remain open and are unaffected by this release.