### PR TITLE
fix(notification): isolate per-message FCM decrypt failures (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **FCM listener no longer dies in a reconnect loop on an undecryptable push** (#25) — after the #21 padding fix, a malformed `crypto-key` (`dh=`) value that decodes to an invalid P-256 point made `http_ece` raise `ValueError: Invalid EC key`, which (like any decrypt error) propagated to the upstream `_listen` catch-all and shut the client down. Because the crash happened before the message was acknowledged, MCS redelivered the same poisoned message on every reconnect — an endless crash/restart loop with no notifications. The per-message decrypt is now isolated: any decode/decrypt failure is logged and that single message is skipped (empty payload) so the upstream handler acks it and the listener stays alive to process the next push.
+
 ## [0.16.6] - 2026-06-18
 
 ### Fixed

--- a/custom_components/fermax_blue/notification.py
+++ b/custom_components/fermax_blue/notification.py
@@ -88,36 +88,53 @@ def _b64_pad(value: str) -> str:
     return value + "=" * (-len(value) % 4)
 
 
-def _patch_fcm_crypto_key_padding() -> None:
-    """Make firebase_messaging tolerant of unpadded crypto-key/encryption headers.
+def _patch_fcm_decrypt() -> None:
+    """Make firebase_messaging's per-message decrypt resilient (issues #21, #25).
 
-    Upstream ``FcmPushClient._decrypt_raw_data`` pads the stored ``private`` and
-    ``secret`` keys before base64-decoding them, but NOT the per-message
-    ``crypto-key`` (dh=) and ``encryption`` (salt=) headers. Some FCM data
-    messages carry header values whose base64 length is not a multiple of 4, so
-    ``urlsafe_b64decode`` raises ``binascii.Error: Incorrect padding`` inside the
-    ``_listen`` loop. The upstream catch-all treats that as an unknown error and
-    shuts the whole client down, taking push notifications offline (issue #21).
+    Two upstream weaknesses let a single bad push crash the whole FcmPushClient,
+    because ``_handle_data_message`` does not guard ``_decrypt_raw_data`` and any
+    exception propagates to the ``_listen`` catch-all that shuts the client down:
 
-    Right-pad both headers before delegating to the original implementation; the
-    padding is deterministic from the string length, so a correctly-padded value
-    is passed through unchanged. Idempotent: safe to call on every (re)start.
+    1. ``_decrypt_raw_data`` base64-decodes the per-message ``crypto-key`` (dh=)
+       and ``encryption`` (salt=) headers without padding them, so an unpadded
+       value (legal per RFC 8188/8291) raises ``binascii.Error: Incorrect
+       padding`` (issue #21).
+    2. Even with padding fixed, a malformed ``dh`` value decodes to bytes that
+       are not a valid P-256 point, so ``http_ece`` raises
+       ``ValueError: Invalid EC key`` (issue #25). The exception propagates
+       before the listen loop records/acks the message, so MCS redelivers the
+       same poisoned message on every reconnect — an endless crash/restart loop.
+
+    Pad both headers before decoding, and swallow any decrypt failure by
+    returning ``b""``: the upstream handler then logs a decrypt warning, acks the
+    message (breaking the redelivery loop) and the listener stays alive to
+    process the next push. Idempotent: safe to call on every (re)start.
     """
     original = FcmPushClient._decrypt_raw_data
-    if getattr(original, "_fermax_padding_patched", False):
+    if getattr(original, "_fermax_decrypt_patched", False):
         return
 
-    def _decrypt_raw_data_padded(
+    def _decrypt_raw_data_safe(
         credentials: dict[str, dict[str, str]],
         crypto_key_str: str,
         salt_str: str,
         raw_data: bytes,
     ) -> bytes:
-        return original(credentials, _b64_pad(crypto_key_str), _b64_pad(salt_str), raw_data)
+        try:
+            return original(credentials, _b64_pad(crypto_key_str), _b64_pad(salt_str), raw_data)
+        except Exception:
+            # Returning b"" lets the upstream handler ack and skip this single
+            # message (breaking the redelivery loop) instead of letting the
+            # exception tear the whole client down.
+            _LOGGER.warning(
+                "Skipping an undecryptable FCM push; FCM listener kept alive",
+                exc_info=True,
+            )
+            return b""
 
-    _decrypt_raw_data_padded._fermax_padding_patched = True  # type: ignore[attr-defined]
+    _decrypt_raw_data_safe._fermax_decrypt_patched = True  # type: ignore[attr-defined]
     FcmPushClient._decrypt_raw_data = staticmethod(  # type: ignore[assignment]
-        _decrypt_raw_data_padded
+        _decrypt_raw_data_safe
     )
 
 
@@ -246,7 +263,7 @@ class FermaxNotificationListener:
             return
 
         _install_fcm_log_rate_limit()
-        _patch_fcm_crypto_key_padding()
+        _patch_fcm_decrypt()
 
         # Bounded abort: let the upstream client give up after a few sequential
         # errors instead of spinning forever on a poisoned reader; the watchdog

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -20,7 +20,7 @@ from custom_components.fermax_blue.notification import (
     FermaxNotificationListener,
     _b64_pad,
     _FcmExcInfoRateLimitFilter,
-    _patch_fcm_crypto_key_padding,
+    _patch_fcm_decrypt,
 )
 
 
@@ -491,7 +491,7 @@ def test_patch_pads_crypto_key_and_salt_before_delegating(restore_fcm_decrypt):
         return b"decrypted"
 
     FcmPushClient._decrypt_raw_data = staticmethod(_spy)
-    _patch_fcm_crypto_key_padding()
+    _patch_fcm_decrypt()
 
     result = FcmPushClient._decrypt_raw_data({}, "A" * 86, "B" * 87, b"raw")
 
@@ -502,13 +502,29 @@ def test_patch_pads_crypto_key_and_salt_before_delegating(restore_fcm_decrypt):
     assert len(received["salt"]) % 4 == 0
 
 
+def test_patch_returns_empty_bytes_on_decrypt_failure(restore_fcm_decrypt):
+    """A decrypt failure (e.g. malformed dh -> Invalid EC key) is swallowed and
+    returns b"" so the upstream listener acks/skips the poisoned message instead
+    of shutting the whole client down on every reconnect (issue #25)."""
+
+    def _boom(credentials, crypto_key_str, salt_str, raw_data):
+        raise ValueError("Invalid EC key.")
+
+    FcmPushClient._decrypt_raw_data = staticmethod(_boom)
+    _patch_fcm_decrypt()
+
+    result = FcmPushClient._decrypt_raw_data({}, "A" * 86, "B" * 86, b"raw")
+
+    assert result == b""
+
+
 def test_patch_is_idempotent(restore_fcm_decrypt):
     """Calling the patch twice does not re-wrap _decrypt_raw_data."""
     FcmPushClient._decrypt_raw_data = staticmethod(
         lambda credentials, crypto_key_str, salt_str, raw_data: b""
     )
-    _patch_fcm_crypto_key_padding()
+    _patch_fcm_decrypt()
     first = inspect.getattr_static(FcmPushClient, "_decrypt_raw_data")
-    _patch_fcm_crypto_key_padding()
+    _patch_fcm_decrypt()
     second = inspect.getattr_static(FcmPushClient, "_decrypt_raw_data")
     assert first is second


### PR DESCRIPTION
## Summary

Fixes #25. Follow-up to the #21 padding fix.

After #21 stopped the `Incorrect padding` crash, a reporter (@jubepue) hit the **next layer**: a malformed `crypto-key` (`dh=`) value decodes to bytes that aren't a valid P-256 point, so `http_ece` raises `ValueError: Invalid EC key`:

```
ERROR [firebase_messaging.fcmpushclient] Unknown error: Invalid EC key., shutting down FcmPushClient.
  File ".../notification.py", line ..., in _decrypt_raw_data_safe
  File ".../http_ece/__init__.py", line 78, in derive_dh
    pubkey = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256R1(), dh)
ValueError: Invalid EC key.
```

Like any decrypt error, it propagated to firebase_messaging's `_listen` catch-all and shut the client down. Crucially, the crash happens in `_handle_data_message` **before** the listen loop records/acks the message's `persistent_id`, so on reconnect MCS **redelivers the same poisoned message** → crash again → endless restart loop (the 300→600s watchdog cycling the reporter saw), with no notifications and blank streaming (#22).

## Fix

Wrap the patched `_decrypt_raw_data` so any decode/decrypt failure is logged and returns `b""`. The upstream handler then logs "failed to decrypt", **acks and skips that single message** (breaking the redelivery loop), and the listener stays alive to process the next push. The happy path is unchanged (real bytes returned). This mirrors upstream PR sdb9696/firebase-messaging#37 and the per-message isolation aegis-hass uses.

`_patch_fcm_crypto_key_padding` is renamed to `_patch_fcm_decrypt` to reflect the broadened scope (padding + isolation).

## Tests

New test `test_patch_returns_empty_bytes_on_decrypt_failure` (TDD red→green): a raising decrypt now returns `b""` instead of propagating. Existing padding/idempotency tests updated for the rename.

`make check` green: ruff + format + mypy + vulture clean, **172 tests pass**.

## CHANGELOG

Temporary `## [Unreleased]` entry — to be consolidated into the beta entry at release.