### PR TITLE
ci(codeql): advanced setup scoped to the shipped integration

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,11 @@
+name: "Fermax Blue CodeQL config"
+
+# Keep CodeQL focused on the shipped integration (custom_components/).
+# scripts/ is an offline, dev-only utility that decrypts Fermax APK credentials
+# (it must use AES-ECB because that is what the app uses, and it prints the
+# extracted credentials to the user by design); tests/ replicates that crypto to
+# build fixtures. Those paths produce only expected, repeatedly-dismissed alerts,
+# so exclude them from analysis instead of triaging the same findings forever.
+paths-ignore:
+  - scripts
+  - tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "27 3 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Why

CodeQL keeps re-raising the same alerts in `scripts/extract_credentials.py` and its test:
- `py/weak-cryptographic-algorithm` (AES-ECB) — the script decrypts Fermax APK credentials encrypted with AES-ECB by the app; there is no alternative cipher.
- `py/clear-text-logging-sensitive-data` — the offline CLI tool prints the extracted credentials to the user by design (sensitive values are already redacted).

These have been dismissed repeatedly (#9–#18) but reappear with new numbers whenever the script is refactored. They are a dev-only utility, not part of the shipped integration.

## What

Switch CodeQL from **default setup** to an **advanced workflow** with a config that excludes `scripts/` and `tests/` from analysis, keeping the scan focused on `custom_components/` (and workflow files via the `actions` language).

- `.github/workflows/codeql.yml` — advanced CodeQL workflow (python + actions, build-mode none), same `Analyze (<language>)` job names as before.
- `.github/codeql/codeql-config.yml` — `paths-ignore: [scripts, tests]`.

## ⚠️ Required manual step

GitHub does not allow default setup and advanced setup at the same time. **CodeQL default setup must be disabled** (Settings → Code security → CodeQL → switch to advanced / disabled) for this workflow to run; otherwise its analysis step fails with a default-setup conflict. Can be flipped via API too.