### PR TITLE
chore(release): v0.16.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.16.7-beta.1] - 2026-06-18
+## [0.16.7] - 2026-06-19
 
 ### Fixed
 - **FCM listener no longer dies in a reconnect loop on an undecryptable push** (#25) — after the #21 padding fix, a malformed `crypto-key` (`dh=`) value that decodes to an invalid P-256 point made `http_ece` raise `ValueError: Invalid EC key`, which (like any decrypt error) propagated to the upstream `_listen` catch-all and shut the client down. Because the crash happened before the message was acknowledged, MCS redelivered the same poisoned message on every reconnect — an endless crash/restart loop with no notifications. The per-message decrypt is now isolated: any decode/decrypt failure is logged and that single message is skipped (empty payload) so the upstream handler acks it and the listener stays alive to process the next push.

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.1.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.16.7-beta.1"
+  "version": "0.16.7"
 }


### PR DESCRIPTION
Promote 0.16.7-beta.1 → **0.16.7** stable.

The per-message FCM decrypt isolation fix (#25) is confirmed working in the wild by the reporter (FCM now stays connected; #25 closed).

- Bump `manifest.json` to `0.16.7`.
- Consolidate the beta CHANGELOG entry into `## [0.16.7]`.