### PR TITLE
Make live-video deps (pymediasoup/aiortc) optional so the integration loads on HA 2026.7+

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,7 +10,7 @@ RUN pip install --no-cache-dir \
     pytest pytest-asyncio pytest-cov \
     httpx firebase-messaging homeassistant \
     "python-socketio[asyncio_client]>=5.12.0" \
-    "av==13.1.0" pymediasoup Pillow \
+    "av==13.1.0" pymediasoup Pillow numpy PyTurboJPEG \
     && pip install --no-cache-dir "aiodns==3.2.0" "pycares==4.4.0"
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This integration simulates a Fermax Blue mobile app client, connecting to the Fe
 
 ## Features
 
-- **Live video streaming** — Real-time MJPEG video from the intercom camera (~720x480, ~24fps). The card auto-switches between static preview and live stream
+- **Live video streaming** — Real-time MJPEG video from the intercom camera (~720x480, ~24fps). The card auto-switches between static preview and live stream. Requires the optional `pymediasoup` package — see [Live video not available on HA 2026.7+](#live-video-not-available-on-ha-20267)
 - **Camera preview** — Last captured frame persists across HA restarts, always visible in the camera card
 - **Doorbell detection** — Real-time push notification when someone rings (via Firebase Cloud Messaging)
 - **Door opening** — Open your building's door remotely (lock entity + button)
@@ -322,6 +322,12 @@ The integration needs to register with Firebase Cloud Messaging. This happens au
 
 ### Camera shows no image
 Press the "Camera preview" button to trigger the first stream. After that, the last frame will be saved and shown as preview even after restarts.
+
+### Live video not available on HA 2026.7+
+Home Assistant 2026.7 ships `av>=17`, and `aiortc` (a dependency of `pymediasoup`, the library that powers live video) has no release compatible with it yet. To keep the integration loading at all, the live-video dependencies are **optional** since v0.16.8: everything else works normally — doorbell detection, door opening, visitor photos, F1, DND, photo caller, call log — and the camera keeps showing the last visitor photo. Only live video/audio streaming is disabled, with a WARNING in the logs when a stream is requested.
+
+- **On HA 2026.6 or older** you can restore live video by installing the package manually into the Home Assistant Python environment and restarting HA, e.g. on a container/Supervised install: `docker exec homeassistant pip install "pymediasoup>=1.1.0"` (repeat after HA core updates). Installs that upgraded from v0.16.7 or earlier usually still have it installed.
+- **On HA 2026.7+** there is currently no way to install a compatible `pymediasoup`. The hard requirement will be restored in a future release once `aiortc` supports `av>=17`.
 
 ### Diagnostics
 For troubleshooting, you can download diagnostics from **Settings** > **Devices & Services** > **Fermax Blue** > **3 dots menu** > **Download diagnostics**. Credentials are automatically redacted.

--- a/custom_components/fermax_blue/camera.py
+++ b/custom_components/fermax_blue/camera.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN, SIGNAL_DOORBELL_RING
 from .coordinator import FermaxBlueCoordinator
 from .entity import FermaxBlueEntity
+from .streaming import streaming_deps_available
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -143,6 +144,14 @@ class FermaxCamera(FermaxBlueEntity, Camera):
 
     async def async_turn_on(self) -> None:
         """Start live camera stream via auto-on + mediasoup."""
+        if not streaming_deps_available():
+            _LOGGER.warning(
+                "Live video is unavailable for %s: optional streaming "
+                "dependencies (pymediasoup/aiortc) are not installed",
+                self.entity_id,
+            )
+            return
+
         result = await self.coordinator.start_camera_preview()
         if result:
             _LOGGER.info("Camera auto-on started: %s", result.description)

--- a/custom_components/fermax_blue/coordinator.py
+++ b/custom_components/fermax_blue/coordinator.py
@@ -39,7 +39,7 @@ from .const import (
     SIGNAL_DOORBELL_RING,
 )
 from .notification import FermaxNotificationListener, _redact_notification
-from .streaming import DEFAULT_SIGNALING_URL, FermaxStreamSession
+from .streaming import DEFAULT_SIGNALING_URL, FermaxStreamSession, streaming_deps_available
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -449,6 +449,14 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
             _LOGGER.error("Cannot start camera: no FCM token available")
             return None
 
+        if not streaming_deps_available():
+            _LOGGER.warning(
+                "Camera preview unavailable: optional live-video dependencies "
+                "(pymediasoup/aiortc) are not installed; skipping auto-on so the "
+                "intercom is not woken up for a stream that cannot start"
+            )
+            return None
+
         result = await self.api.auto_on(
             self.pairing.device_id,
             self.notification_listener.fcm_token,
@@ -518,6 +526,14 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
 
     async def _start_stream(self, room_id: str, signaling_url: str, fermax_token: str = "") -> None:
         """Start a video stream session for the given room."""
+        if not streaming_deps_available():
+            _LOGGER.warning(
+                "Ignoring stream request for room %s: optional live-video "
+                "dependencies (pymediasoup/aiortc) are not installed",
+                room_id,
+            )
+            return
+
         await self.stop_stream()
 
         if not self.notification_listener:

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/bvis/fermax-blue-hass",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
-  "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.1.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
+  "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
   "version": "0.16.7"
 }

--- a/custom_components/fermax_blue/streaming.py
+++ b/custom_components/fermax_blue/streaming.py
@@ -418,6 +418,21 @@ class FermaxStreamSession:
         """Start the full streaming pipeline."""
         try:
             return await self._start_inner()
+        except ImportError as err:
+            # Live video needs pymediasoup + aiortc. These are optional (not in
+            # manifest requirements) because aiortc currently caps av<17, which
+            # conflicts with Home Assistant builds shipping av>=17 (2026.7+),
+            # making them unresolvable. The rest of the integration (door open,
+            # calls, sensors) works fine; only live streaming is unavailable.
+            _LOGGER.warning(
+                "Fermax Blue live video is unavailable: optional streaming "
+                "dependencies (pymediasoup/aiortc) are not installed. This is "
+                "expected on Home Assistant builds using av>=17 (aiortc has no "
+                "compatible release yet). Everything else works normally. (%s)",
+                err,
+            )
+            await self.stop()
+            return False
         except Exception:
             _LOGGER.exception("Failed to start stream session")
             await self.stop()

--- a/custom_components/fermax_blue/streaming.py
+++ b/custom_components/fermax_blue/streaming.py
@@ -21,11 +21,26 @@ import logging
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
+from functools import cache
+from importlib.util import find_spec
 from typing import Any
 
 import socketio
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@cache
+def streaming_deps_available() -> bool:
+    """Return True when the optional live-video deps (pymediasoup/aiortc) are installed.
+
+    They are not in the manifest requirements because aiortc pins av<17, which
+    conflicts with the av>=17 shipped by Home Assistant 2026.7+. Callers must
+    skip stream work — including the auto-on request that wakes the physical
+    intercom — when this returns False.
+    """
+    return find_spec("pymediasoup") is not None
+
 
 # Suppress noisy H264 decode warnings (expected on stream start before first keyframe)
 logging.getLogger("aiortc.codecs.h264").setLevel(logging.ERROR)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -100,6 +100,52 @@ def coordinator(mock_hass, mock_api, pairing):
     return coord
 
 
+class TestStreamingDepsGuard:
+    """Optional live-video deps: never wake the intercom when they are missing."""
+
+    @pytest.mark.asyncio
+    async def test_preview_skipped_without_deps(self, coordinator, mock_api):
+        coordinator.notification_listener = MagicMock()
+        coordinator.notification_listener.fcm_token = "tok"
+
+        with patch(
+            "custom_components.fermax_blue.coordinator.streaming_deps_available",
+            return_value=False,
+        ):
+            result = await coordinator.start_camera_preview()
+
+        assert result is None
+        mock_api.auto_on.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_preview_requests_auto_on_with_deps(self, coordinator, mock_api):
+        coordinator.notification_listener = MagicMock()
+        coordinator.notification_listener.fcm_token = "tok"
+        mock_api.auto_on = AsyncMock(return_value=None)
+
+        with patch(
+            "custom_components.fermax_blue.coordinator.streaming_deps_available",
+            return_value=True,
+        ):
+            await coordinator.start_camera_preview()
+
+        mock_api.auto_on.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_start_stream_skipped_without_deps(self, coordinator):
+        coordinator._stream_session = None
+        coordinator.stop_stream = AsyncMock()
+
+        with patch(
+            "custom_components.fermax_blue.coordinator.streaming_deps_available",
+            return_value=False,
+        ):
+            await coordinator._start_stream("room1", "https://signaling-pro-duoxme.fermax.io")
+
+        coordinator.stop_stream.assert_not_awaited()
+        assert coordinator.stream_session is None
+
+
 class TestCoordinatorDnd:
     """Test DND coordination."""
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,7 +1,7 @@
 """Tests for entity platforms."""
 
 from datetime import UTC
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -393,3 +393,37 @@ class TestOptimisticSwitches:
         mock_coordinator.set_photo_caller.assert_awaited_once_with(True)
         # After completion, optimistic state is cleared; falls back to coordinator
         assert switch.is_on is True  # device_info.photocaller = True in fixture
+
+
+class TestCameraStreamingDepsGuard:
+    """Camera turn_on must not request auto-on when live-video deps are missing."""
+
+    def _make_camera(self, mock_coordinator):
+        from custom_components.fermax_blue.camera import FermaxCamera
+
+        return FermaxCamera(mock_coordinator)
+
+    @pytest.mark.asyncio
+    async def test_turn_on_skipped_without_deps(self, mock_coordinator):
+        camera = self._make_camera(mock_coordinator)
+
+        with patch(
+            "custom_components.fermax_blue.camera.streaming_deps_available",
+            return_value=False,
+        ):
+            await camera.async_turn_on()
+
+        mock_coordinator.start_camera_preview.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_turn_on_starts_preview_with_deps(self, mock_coordinator):
+        camera = self._make_camera(mock_coordinator)
+        mock_coordinator.start_camera_preview = AsyncMock(return_value=None)
+
+        with patch(
+            "custom_components.fermax_blue.camera.streaming_deps_available",
+            return_value=True,
+        ):
+            await camera.async_turn_on()
+
+        mock_coordinator.start_camera_preview.assert_awaited_once()

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,23 @@
+"""Tests for the streaming module."""
+
+from unittest.mock import patch
+
+from custom_components.fermax_blue.streaming import streaming_deps_available
+
+
+class TestStreamingDepsAvailable:
+    """Detection of the optional live-video dependencies."""
+
+    def test_true_when_pymediasoup_installed(self):
+        streaming_deps_available.cache_clear()
+        assert streaming_deps_available() is True
+        streaming_deps_available.cache_clear()
+
+    def test_false_when_pymediasoup_missing(self):
+        streaming_deps_available.cache_clear()
+        with patch(
+            "custom_components.fermax_blue.streaming.find_spec",
+            return_value=None,
+        ):
+            assert streaming_deps_available() is False
+        streaming_deps_available.cache_clear()


### PR DESCRIPTION
## Problem

On **Home Assistant 2026.7+**, the whole integration fails to set up:

```
Setup failed for custom integration 'fermax_blue':
Requirements for fermax_blue not found: ['pymediasoup>=1.1.0'].
```

with, underneath:

```
× No solution found when resolving dependencies:
  ╰─▶ Because ... aiortc==1.14.0 depends on av>=14.0.0,<17 and av==17.0.1,
      we can conclude that aiortc>=... cannot be used.
```

## Root cause

HA 2026.7 pins **`av==17.0.1`** (used by the `stream`/camera stack). `pymediasoup`
pulls in **`aiortc`**, and the newest `aiortc` (1.14.0) still caps **`av<17`**. So
`pymediasoup>=1.1.0` in `requirements` is unresolvable under HA's global
constraints, and HA aborts setup of the **entire** integration — taking
door-open, calls and sensors down with it, not just the camera.

This will keep happening for every aiortc-based integration until aiortc ships an
av>=17 compatible release.

## Fix

`pymediasoup`/`aiortc` are only imported **lazily inside `streaming.py`** (live
video). This PR:

1. Removes `pymediasoup>=1.1.0` from `manifest.json` `requirements`, so the
   integration loads on HA 2026.7+ (and the core intercom features keep working).
2. Turns the now-possible `ImportError` in `FermaxStreamSession.start()` into a
   single clear `warning` instead of a full traceback, so live video degrades
   gracefully until aiortc supports av>=17 (or the user installs the deps
   manually on a compatible build).

No module-level imports of `pymediasoup`/`aiortc` exist, so removing the hard
requirement is safe.

## Testing

Applied on a live HA **2026.7.1** install: integration now sets up cleanly,
`binary_sensor.*_conexion` is `on`, door/call/aux buttons are available. Only the
live camera stream is unavailable (expected — aiortc can't run on av 17 yet).
