### PR TITLE
feat(streaming): restore pymediasoup/aiortc as hard requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This integration simulates a Fermax Blue mobile app client, connecting to the Fe
 
 ## Features
 
-- **Live video streaming** — Real-time MJPEG video from the intercom camera (~720x480, ~24fps). The card auto-switches between static preview and live stream. Requires the optional `pymediasoup` package — see [Live video not available on HA 2026.7+](#live-video-not-available-on-ha-20267)
+- **Live video streaming** — Real-time MJPEG video from the intercom camera (~720x480, ~24fps). The card auto-switches between static preview and live stream.
 - **Camera preview** — Last captured frame persists across HA restarts, always visible in the camera card
 - **Doorbell detection** — Real-time push notification when someone rings (via Firebase Cloud Messaging)
 - **Door opening** — Open your building's door remotely (lock entity + button)
@@ -323,11 +323,10 @@ The integration needs to register with Firebase Cloud Messaging. This happens au
 ### Camera shows no image
 Press the "Camera preview" button to trigger the first stream. After that, the last frame will be saved and shown as preview even after restarts.
 
-### Live video not available on HA 2026.7+
-Home Assistant 2026.7 ships `av>=17`, and `aiortc` (a dependency of `pymediasoup`, the library that powers live video) has no release compatible with it yet. To keep the integration loading at all, the live-video dependencies are **optional** since v0.16.8: everything else works normally — doorbell detection, door opening, visitor photos, F1, DND, photo caller, call log — and the camera keeps showing the last visitor photo. Only live video/audio streaming is disabled, with a WARNING in the logs when a stream is requested.
+### Live video not working after upgrading
+Live video is powered by `pymediasoup`/`aiortc`. On v0.16.8 these were temporarily **optional** because no `aiortc` release was compatible with the `av>=17` shipped by Home Assistant 2026.7 — live streaming was disabled on those systems. Since `aiortc` 1.15.0 (compatible with `av 17`) they are regular requirements again and live video works on all supported HA versions.
 
-- **On HA 2026.6 or older** you can restore live video by installing the package manually into the Home Assistant Python environment and restarting HA, e.g. on a container/Supervised install: `docker exec homeassistant pip install "pymediasoup>=1.1.0"` (repeat after HA core updates). Installs that upgraded from v0.16.7 or earlier usually still have it installed.
-- **On HA 2026.7+** there is currently no way to install a compatible `pymediasoup`. The hard requirement will be restored in a future release once `aiortc` supports `av>=17`.
+If live video is unavailable and the logs show a WARNING about missing streaming dependencies, restart Home Assistant so it installs the integration requirements. Everything else — doorbell detection, door opening, visitor photos, F1, DND, photo caller, call log — works normally even without them.
 
 ### Diagnostics
 For troubleshooting, you can download diagnostics from **Settings** > **Devices & Services** > **Fermax Blue** > **3 dots menu** > **Download diagnostics**. Credentials are automatically redacted.

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/bvis/fermax-blue-hass",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
-  "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
+  "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.5.0", "aiortc>=1.15.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
   "version": "0.16.8"
 }

--- a/custom_components/fermax_blue/streaming.py
+++ b/custom_components/fermax_blue/streaming.py
@@ -32,12 +32,13 @@ _LOGGER = logging.getLogger(__name__)
 
 @cache
 def streaming_deps_available() -> bool:
-    """Return True when the optional live-video deps (pymediasoup/aiortc) are installed.
+    """Return True when the live-video deps (pymediasoup/aiortc) are installed.
 
-    They are not in the manifest requirements because aiortc pins av<17, which
-    conflicts with the av>=17 shipped by Home Assistant 2026.7+. Callers must
-    skip stream work — including the auto-on request that wakes the physical
-    intercom — when this returns False.
+    They are back in the manifest requirements since aiortc 1.15.0 supports
+    av>=17, but installs that upgraded while the deps were optional may still
+    lack them until HA reinstalls requirements. Callers must skip stream work —
+    including the auto-on request that wakes the physical intercom — when this
+    returns False.
     """
     return find_spec("pymediasoup") is not None
 
@@ -434,16 +435,16 @@ class FermaxStreamSession:
         try:
             return await self._start_inner()
         except ImportError as err:
-            # Live video needs pymediasoup + aiortc. These are optional (not in
-            # manifest requirements) because aiortc currently caps av<17, which
-            # conflicts with Home Assistant builds shipping av>=17 (2026.7+),
-            # making them unresolvable. The rest of the integration (door open,
-            # calls, sensors) works fine; only live streaming is unavailable.
+            # Live video needs pymediasoup + aiortc. They are manifest
+            # requirements again, but may be missing on installs that upgraded
+            # while the deps were optional (v0.16.8) until HA reinstalls
+            # requirements. The rest of the integration (door open, calls,
+            # sensors) works fine; only live streaming is unavailable.
             _LOGGER.warning(
-                "Fermax Blue live video is unavailable: optional streaming "
-                "dependencies (pymediasoup/aiortc) are not installed. This is "
-                "expected on Home Assistant builds using av>=17 (aiortc has no "
-                "compatible release yet). Everything else works normally. (%s)",
+                "Fermax Blue live video is unavailable: streaming dependencies "
+                "(pymediasoup/aiortc) are not installed. Restart Home Assistant "
+                "so it installs the integration requirements. Everything else "
+                "works normally. (%s)",
                 err,
             )
             await self.stop()


### PR DESCRIPTION
## Summary

aiortc **1.15.0** is out on PyPI with `av>=14,<18`, compatible with the `av==17.0.1` pinned by Home Assistant 2026.7+. This restores the live-video dependencies as hard requirements, undoing the temporary optionality introduced in v0.16.8 (#35).

- Re-add `pymediasoup>=1.5.0` to manifest requirements, plus an explicit `aiortc>=1.15.0` so a resolver running without HA's constraints file can never pick aiortc 1.14 and downgrade `av`
- Keep `streaming_deps_available()` and all guards as defense in depth — installs that upgraded during v0.16.8 may still lack the deps until HA reinstalls requirements; the ImportError warning now tells users to restart HA
- Rewrite the README section as "Live video not working after upgrading" and drop the HA 2026.7 limitation from the Features list

Closes #38

## Verification

- `make pre-push` green locally: lint, format, mypy, vulture, 179 tests on Python 3.12 + 3.13
- Dependency chain verified on PyPI: pymediasoup 1.5.0 → `aiortc>=1.14,<2` → aiortc 1.15.0 → `av>=14,<18`; HA 2026.7 `package_constraints.txt` pins `av==17.0.1`
- Live-video verification on a real HA 2026.7+ instance planned as part of the beta release