### PR TITLE
chore(release): v0.17.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.17.0-beta.1] - 2026-07-18
+
+### Changed
+- **Live video restored on Home Assistant 2026.7+** (#38) — `aiortc` 1.15.0 supports `av>=14,<18`, compatible with the `av==17.0.1` shipped by HA 2026.7+, so the live-video dependencies are hard requirements again: `pymediasoup>=1.5.0` and `aiortc>=1.15.0` are back in the manifest and installed automatically — no manual `pip install` needed on any supported HA version. The v0.16.8 availability guards remain as defense in depth: installs that upgraded while the deps were optional keep working (a restart lets HA install the requirements), and everything except live video continues to work if they are ever missing (#39).
+
 ## [0.16.8] - 2026-07-07
 
 ### Fixed

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.5.0", "aiortc>=1.15.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.16.8"
+  "version": "0.17.0-beta.1"
 }


### PR DESCRIPTION
Prerelease for the #38 fix (restore pymediasoup/aiortc hard requirements, #39). Bumps manifest version and adds the CHANGELOG entry. Will be published as a prerelease for beta verification before promoting to 0.17.0 stable.