### PR TITLE
fix(sensor): redact email PII in last-opening attributes

### DIFF
--- a/custom_components/fermax_blue/api.py
+++ b/custom_components/fermax_blue/api.py
@@ -50,6 +50,26 @@ def _redact_sensitive_text(text: str, extra_values: tuple[str | None, ...] = ())
     )
 
 
+def redact_email(value: str | None) -> str | None:
+    """Partially redact an email for exposure in entity attributes.
+
+    ``basilio.vera@gmail.com`` -> ``b***a@g***.com``. Local parts of one or
+    two characters are fully masked; strings without ``@`` (display names)
+    pass through unchanged, as do ``None`` and ``""``.
+    """
+    if not value or "@" not in value:
+        return value
+    local, domain = value.rsplit("@", 1)
+    local_masked = f"{local[0]}***{local[-1]}" if len(local) > 2 else "***"
+    if not domain:
+        domain_masked = "***"
+    elif "." in domain:
+        domain_masked = f"{domain[0]}***.{domain.rsplit('.', 1)[1]}"
+    else:
+        domain_masked = f"{domain[0]}***"
+    return f"{local_masked}@{domain_masked}"
+
+
 def _truncate_for_log(text: str, limit: int = AUTH_RESPONSE_LOG_BODY_LIMIT) -> str:
     """Return a bounded string suitable for logs."""
     if len(text) <= limit:

--- a/custom_components/fermax_blue/sensor.py
+++ b/custom_components/fermax_blue/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .api import redact_email
 from .const import DOMAIN
 from .coordinator import FermaxBlueCoordinator
 from .entity import FermaxBlueEntity
@@ -108,9 +109,9 @@ class FermaxSensor(FermaxBlueEntity, SensorEntity):
                 return None
             record = self.coordinator.last_opening
             return {
-                "user": record.user,
+                "user": redact_email(record.user),
                 "door": record.door,
-                "guest_email": record.guest_email,
+                "guest_email": redact_email(record.guest_email),
             }
         if self._key == "last_call":
             if not self.coordinator.last_call:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -666,3 +666,52 @@ class TestFrozenModels:
         record = OpeningRecord(timestamp="2026-01-01", user="u", door="d")
         with pytest.raises(FrozenInstanceError):
             record.user = "other"
+
+
+class TestRedactEmail:
+    """Tests for the redact_email() PII helper."""
+
+    def test_normal_email(self):
+        from custom_components.fermax_blue.api import redact_email
+
+        assert redact_email("basilio.vera@gmail.com") == "b***a@g***.com"
+
+    def test_short_local_two_chars(self):
+        from custom_components.fermax_blue.api import redact_email
+
+        assert redact_email("jo@example.com") == "***@e***.com"
+
+    def test_short_local_one_char(self):
+        from custom_components.fermax_blue.api import redact_email
+
+        assert redact_email("j@example.com") == "***@e***.com"
+
+    def test_multi_dot_domain(self):
+        from custom_components.fermax_blue.api import redact_email
+
+        assert redact_email("jo@sub.example.co.uk") == "***@s***.uk"
+
+    def test_domain_without_dots(self):
+        from custom_components.fermax_blue.api import redact_email
+
+        assert redact_email("user@localhost") == "u***r@l***"
+
+    def test_non_email_passes_through(self):
+        from custom_components.fermax_blue.api import redact_email
+
+        assert redact_email("Portero") == "Portero"
+
+    def test_none_passes_through(self):
+        from custom_components.fermax_blue.api import redact_email
+
+        assert redact_email(None) is None
+
+    def test_empty_string_passes_through(self):
+        from custom_components.fermax_blue.api import redact_email
+
+        assert redact_email("") == ""
+
+    def test_empty_domain(self):
+        from custom_components.fermax_blue.api import redact_email
+
+        assert redact_email("user@") == "u***r@***"

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -267,7 +267,23 @@ class TestLastOpeningSensor:
         sensor = FermaxLastOpeningSensor(mock_coordinator)
         assert sensor.native_value == "2026-04-05T10:30:00Z"
 
-    def test_last_opening_extra_attrs(self, mock_coordinator):
+    def test_last_opening_extra_attrs_redacts_emails(self, mock_coordinator):
+        from custom_components.fermax_blue.api import OpeningRecord
+        from custom_components.fermax_blue.sensor import FermaxLastOpeningSensor
+
+        mock_coordinator.last_opening = OpeningRecord(
+            timestamp="2026-04-05T10:30:00Z",
+            user="john.doe@example.com",
+            door="Portal",
+            guest_email="guest@test.com",
+        )
+        sensor = FermaxLastOpeningSensor(mock_coordinator)
+        attrs = sensor.extra_state_attributes
+        assert attrs["user"] == "j***e@e***.com"
+        assert attrs["door"] == "Portal"
+        assert attrs["guest_email"] == "g***t@t***.com"
+
+    def test_last_opening_extra_attrs_non_email_user(self, mock_coordinator):
         from custom_components.fermax_blue.api import OpeningRecord
         from custom_components.fermax_blue.sensor import FermaxLastOpeningSensor
 
@@ -275,13 +291,11 @@ class TestLastOpeningSensor:
             timestamp="2026-04-05T10:30:00Z",
             user="John",
             door="Portal",
-            guest_email="guest@test.com",
         )
         sensor = FermaxLastOpeningSensor(mock_coordinator)
         attrs = sensor.extra_state_attributes
         assert attrs["user"] == "John"
-        assert attrs["door"] == "Portal"
-        assert attrs["guest_email"] == "guest@test.com"
+        assert attrs["guest_email"] is None
 
 
 class TestLastCallSensor:


### PR DESCRIPTION
## Summary

The `last_opening` sensor exposed the opener's full email (`user`) and `guest_email` in entity attributes. Sensor attributes are persisted by the recorder database, shown in logbook/dashboards, and included in exports — so full email addresses ended up stored in clear text. This was flagged as **M-3** in the initial security review (#1) and deferred at the time.

Both attributes are now partially redacted at the exposure boundary; the raw data never leaves the coordinator.

## Before / after

| Attribute | Before | After |
|---|---|---|
| `user` | `john.doe@example.com` | `j***e@e***.com` |
| `guest_email` | `guest@test.com` | `g***t@t***.com` |
| `user` (display name) | `Portero` | `Portero` (unchanged) |

Redaction rules: first + last character of the local part (fully masked when ≤2 chars), first character of the domain + real TLD. Strings without `@`, `None`, and empty strings pass through unchanged.

## Changes

- New `redact_email()` helper in `api.py`, next to the existing redaction utilities (9 unit tests).
- `sensor.py` applies it to `user` / `guest_email` in `extra_state_attributes` (2 sensor tests updated/added).
- `OpeningRecord` and every other code path are unchanged.

## Breaking-ish note

Automations or template sensors comparing the **full email** in these attributes will need updating — this will be called out again in the release notes. Semver stays **patch** (privacy/security correction, no new functionality).

## Testing

- TDD: tests written first and verified red before each change.
- `make check` green (lint, format, mypy, vulture, 189 tests).
- `make pre-push` green on Python 3.12 + 3.13.