### PR TITLE
chore(release): v0.17.1-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.17.1-beta.1] - 2026-07-18
+
+### Fixed
+- **Email addresses no longer stored in clear text by the recorder** (#42) — the `last_opening` sensor exposed the opener's full email (`user`) and `guest_email` in its entity attributes, so full addresses were persisted in the recorder database and shown in logbook, dashboards, and exports. Both attributes are now partially redacted (`john.doe@example.com` → `j***e@e***.com`); non-email display names pass through unchanged. **Note:** automations or template sensors comparing the full email in these attributes need updating to the redacted format.
+
 ## [0.17.0] - 2026-07-18
 
 ### Changed

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.5.0", "aiortc>=1.15.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.17.0"
+  "version": "0.17.1-beta.1"
 }


### PR DESCRIPTION
Prerelease for the PII redaction fix (#42, review item M-3 from #1).

- Manifest version → `0.17.1-beta.1`
- CHANGELOG entry, including the note that automations comparing the full email in `last_opening` attributes need updating to the redacted format.

After merge: publish prerelease `v0.17.1-beta.1`, deploy + verify on live HA (redacted attribute, clean logs), then promote to `v0.17.1` stable.