### PR TITLE
chore(release): v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.17.1-beta.1] - 2026-07-18
+## [0.17.1] - 2026-07-18
 
 ### Fixed
 - **Email addresses no longer stored in clear text by the recorder** (#42) — the `last_opening` sensor exposed the opener's full email (`user`) and `guest_email` in its entity attributes, so full addresses were persisted in the recorder database and shown in logbook, dashboards, and exports. Both attributes are now partially redacted (`john.doe@example.com` → `j***e@e***.com`); non-email display names pass through unchanged. **Note:** automations or template sensors comparing the full email in these attributes need updating to the redacted format.

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.5.0", "aiortc>=1.15.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.17.1-beta.1"
+  "version": "0.17.1"
 }


### PR DESCRIPTION
Promote v0.17.1-beta.1 to stable. Beta verified on live HA: clean startup, FCM up, recorder confirmed storing the redacted `user` attribute.

- Manifest version → `0.17.1`
- CHANGELOG consolidated into `## [0.17.1]`