### PR TITLE
feat(streaming): opt-in receive-only preview stream on ring

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ For each paired intercom device, the integration creates:
 | `switch.<name>_notifications` | Switch | Enable/disable push notifications |
 | `switch.<name>_dnd` | Switch | Do Not Disturb mode |
 | `switch.<name>_photo_caller` | Switch | Enable/disable automatic visitor photos |
+| `switch.<name>_ring_preview` | Switch | Live preview on ring (default: off) — starts a view-only video stream when someone rings, so the camera shows the current visitor within a few seconds. The call is never answered and keeps ringing; no audio is sent or received. Stops after the stream duration or when the call ends |
 
 ## Dashboard Card
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,15 @@ For each paired intercom device, the integration creates:
 | `switch.<name>_notifications` | Switch | Enable/disable push notifications |
 | `switch.<name>_dnd` | Switch | Do Not Disturb mode |
 | `switch.<name>_photo_caller` | Switch | Enable/disable automatic visitor photos |
-| `switch.<name>_ring_preview` | Switch | Live preview on ring (default: off) — starts a view-only video stream when someone rings, so the camera shows the current visitor within a few seconds. The call is never answered and keeps ringing; no audio is sent or received. Stops after the stream duration or when the call ends |
+| `switch.<name>_ring_preview` | Switch | Enable/disable live view-only preview on ring without answering the call (see [Ring preview](#ring-preview)) |
+
+### Ring preview
+
+When the `ring_preview` switch is on, a doorbell ring starts a view-only video stream. The camera shows the current visitor within a few seconds while the panel keeps ringing. The call isn't answered and no audio is sent or received.
+
+- The switch only has an effect in `notify_only` call mode. `record` and `auto_respond` already start a stream by answering the call.
+- The stream stops after the configured stream duration, capped by a server-side preview limit of about 29 seconds.
+- Like any stream session, the preview is recorded to the media folder (subject to the recording retention setting) and updates the last visitor photo. Every ring leaves a snapshot without answering.
 
 ## Dashboard Card
 

--- a/custom_components/fermax_blue/coordinator.py
+++ b/custom_components/fermax_blue/coordinator.py
@@ -98,6 +98,7 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
         self._stream_session: FermaxStreamSession | None = None
         self._storage_path: Path | None = None
         self._auto_response_file = auto_response_file
+        self._ring_preview = False
         self._call_mode = CALL_MODE_NOTIFY
         self._stream_duration = DEFAULT_STREAM_DURATION
         self._stream_stop_unsub: CALLBACK_TYPE | None = None
@@ -114,6 +115,16 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
     def call_mode(self, value: str) -> None:
         """Set the call mode."""
         self._call_mode = value
+
+    @property
+    def ring_preview(self) -> bool:
+        """Return whether the receive-only ring preview is enabled."""
+        return self._ring_preview
+
+    @ring_preview.setter
+    def ring_preview(self, value: bool) -> None:
+        """Enable or disable the receive-only ring preview."""
+        self._ring_preview = value
 
     @property
     def stream_duration(self) -> int:
@@ -353,11 +364,15 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
 
         # Start video stream based on call mode:
         # - Autoon (camera preview button): always start stream
-        # - Call (doorbell): depends on call_mode setting
+        # - Call (doorbell): depends on call_mode setting; with the ring
+        #   preview option a receive-only stream starts even in notify mode,
+        #   showing the current visitor without answering the call
         room_id = data.get("RoomId")
+        attend = notification_type == "Call" and self._call_mode != CALL_MODE_NOTIFY
         should_stream = room_id and (
             notification_type == "Autoon"
-            or (notification_type == "Call" and self._call_mode != CALL_MODE_NOTIFY)
+            or attend
+            or (notification_type == "Call" and self._ring_preview)
         )
         if should_stream:
             socket_url = data.get("SocketUrl", DEFAULT_SIGNALING_URL)
@@ -368,7 +383,10 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
                 )
                 socket_url = DEFAULT_SIGNALING_URL
             fermax_token = data.get("FermaxToken", "")
-            self.hass.async_create_task(self._start_stream(room_id, socket_url, fermax_token))
+            receive_only = notification_type == "Call" and not attend
+            self.hass.async_create_task(
+                self._start_stream(room_id, socket_url, fermax_token, receive_only=receive_only)
+            )
             if (
                 notification_type == "Call"
                 and self._call_mode == CALL_MODE_AUTO_RESPOND
@@ -524,7 +542,13 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
         if self.device_info:
             self.device_info = replace(self.device_info, photocaller=enabled)
 
-    async def _start_stream(self, room_id: str, signaling_url: str, fermax_token: str = "") -> None:
+    async def _start_stream(
+        self,
+        room_id: str,
+        signaling_url: str,
+        fermax_token: str = "",
+        receive_only: bool = False,
+    ) -> None:
         """Start a video stream session for the given room."""
         if not streaming_deps_available():
             _LOGGER.warning(
@@ -565,6 +589,7 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
             room_id=room_id,
             on_end=_on_stream_end,
             media_root=media_root,
+            receive_only=receive_only,
         )
 
         success = await self._stream_session.start()

--- a/custom_components/fermax_blue/coordinator.py
+++ b/custom_components/fermax_blue/coordinator.py
@@ -45,6 +45,9 @@ _LOGGER = logging.getLogger(__name__)
 
 DOORBELL_RESET_SECONDS = 30
 CAMERA_TIMEOUT_SECONDS = 90
+# The server bounds unattended preview sessions by the push payload's
+# PreviewTimeout field (29 s by default), independent of our local timer.
+DEFAULT_PREVIEW_TIMEOUT = 29
 # FCM re-delivers recent notifications when the listener reconnects after a
 # reload/restart, causing phantom doorbell rings. Ignore them briefly.
 NOTIFICATION_GRACE_PERIOD = 10
@@ -385,7 +388,13 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
             fermax_token = data.get("FermaxToken", "")
             receive_only = notification_type == "Call" and not attend
             self.hass.async_create_task(
-                self._start_stream(room_id, socket_url, fermax_token, receive_only=receive_only)
+                self._start_stream(
+                    room_id,
+                    socket_url,
+                    fermax_token,
+                    receive_only=receive_only,
+                    preview_timeout=data.get("PreviewTimeout"),
+                )
             )
             if (
                 notification_type == "Call"
@@ -440,7 +449,10 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
                 fcm_token=fcm_token,
                 call_as=self.pairing.device_id,
             )
-        else:
+            if not success:
+                _LOGGER.warning("In-call door open failed, falling back to the standard endpoint")
+
+        if not success:
             door = self.pairing.access_doors.get(door_name)
             if not door:
                 for d in self.pairing.access_doors.values():
@@ -548,6 +560,7 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
         signaling_url: str,
         fermax_token: str = "",
         receive_only: bool = False,
+        preview_timeout: str | int | None = None,
     ) -> None:
         """Start a video stream session for the given room."""
         if not streaming_deps_available():
@@ -598,16 +611,28 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
             _LOGGER.info("Video stream started for room %s", room_id)
             async_dispatcher_send(self.hass, SIGNAL_CAMERA_ON.format(self.pairing.device_id))
 
-            # Schedule auto-stop after configured duration
+            # Schedule auto-stop after configured duration. Receive-only
+            # sessions are torn down server-side after PreviewTimeout
+            # (carried in the push payload, 29 s by default), so clamp the
+            # local timer to it: a longer stream_duration would leave the
+            # entities reporting a live stream after teardown.
+            stop_after = self._stream_duration
+            if receive_only:
+                try:
+                    timeout = int(preview_timeout)  # type: ignore[arg-type]
+                except (TypeError, ValueError):
+                    timeout = DEFAULT_PREVIEW_TIMEOUT
+                if timeout <= 0:
+                    timeout = DEFAULT_PREVIEW_TIMEOUT
+                stop_after = min(stop_after, timeout)
+
             @callback
             def _auto_stop_stream(_now: Any) -> None:
-                _LOGGER.info("Stream auto-stop after %ds", self._stream_duration)
+                _LOGGER.info("Stream auto-stop after %ds", stop_after)
                 self._stream_stop_unsub = None
                 self.hass.async_create_task(self.stop_stream())
 
-            self._stream_stop_unsub = async_call_later(
-                self.hass, self._stream_duration, _auto_stop_stream
-            )
+            self._stream_stop_unsub = async_call_later(self.hass, stop_after, _auto_stop_stream)
         else:
             _LOGGER.warning("Failed to start video stream for room %s", room_id)
             self._stream_session = None

--- a/custom_components/fermax_blue/icons.json
+++ b/custom_components/fermax_blue/icons.json
@@ -45,6 +45,12 @@
         "state": {
           "off": "mdi:camera-off"
         }
+      },
+      "ring_preview": {
+        "default": "mdi:cctv",
+        "state": {
+          "off": "mdi:cctv-off"
+        }
       }
     },
     "lock": {

--- a/custom_components/fermax_blue/number.py
+++ b/custom_components/fermax_blue/number.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.components.number import NumberMode, RestoreNumber
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -30,7 +30,7 @@ async def async_setup_entry(
     async_add_entities(FermaxStreamDurationNumber(c) for c in coordinators)
 
 
-class FermaxStreamDurationNumber(FermaxBlueEntity, NumberEntity):
+class FermaxStreamDurationNumber(FermaxBlueEntity, RestoreNumber):
     """Number entity to control stream duration."""
 
     _attr_translation_key = "stream_duration"
@@ -43,6 +43,13 @@ class FermaxStreamDurationNumber(FermaxBlueEntity, NumberEntity):
     def __init__(self, coordinator: FermaxBlueCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{self._device_id}_stream_duration"
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the previous duration when added to hass."""
+        await super().async_added_to_hass()
+        last = await self.async_get_last_number_data()
+        if last is not None and last.native_value is not None:
+            self.coordinator.stream_duration = int(last.native_value)
 
     @property
     def native_value(self) -> float:

--- a/custom_components/fermax_blue/select.py
+++ b/custom_components/fermax_blue/select.py
@@ -8,6 +8,7 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import CALL_MODES, DOMAIN
 from .coordinator import FermaxBlueCoordinator
@@ -26,7 +27,7 @@ async def async_setup_entry(
     async_add_entities(FermaxCallModeSelect(c) for c in coordinators)
 
 
-class FermaxCallModeSelect(FermaxBlueEntity, SelectEntity):
+class FermaxCallModeSelect(FermaxBlueEntity, SelectEntity, RestoreEntity):
     """Select entity to control doorbell call behavior."""
 
     _attr_translation_key = "call_mode"
@@ -35,6 +36,13 @@ class FermaxCallModeSelect(FermaxBlueEntity, SelectEntity):
     def __init__(self, coordinator: FermaxBlueCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{self._device_id}_call_mode"
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the previous call mode when added to hass."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None and last_state.state in CALL_MODES:
+            self.coordinator.call_mode = last_state.state
 
     @property
     def current_option(self) -> str:

--- a/custom_components/fermax_blue/streaming.py
+++ b/custom_components/fermax_blue/streaming.py
@@ -153,10 +153,12 @@ class FermaxSignalingClient:
         signaling_url: str = DEFAULT_SIGNALING_URL,
         oauth_token: str = "",
         fcm_token: str = "",
+        send_hangup: bool = True,
     ) -> None:
         self._signaling_url = signaling_url
         self._oauth_token = oauth_token
         self._fcm_token = fcm_token
+        self._send_hangup = send_hangup
         self._sio: socketio.AsyncClient | None = None
         self._connected = False
         self._room_join_result: RoomJoinResult | None = None
@@ -364,7 +366,9 @@ class FermaxSignalingClient:
     async def disconnect(self) -> None:
         if self._sio:
             try:
-                if self._connected:
+                # A session that never picked up leaves silently: hang_up on a
+                # still-ringing call could end it for the visitor and monitor.
+                if self._connected and self._send_hangup:
                     await self.hangup()
                 await self._sio.disconnect()
             except Exception:
@@ -389,6 +393,7 @@ class FermaxStreamSession:
         room_id: str,
         on_end: Callable[[], None] | None = None,
         media_root: str = "/media",
+        receive_only: bool = False,
     ) -> None:
         # Enforce secure scheme for signaling URL
         if signaling_url and not signaling_url.startswith(("https://", "wss://")):
@@ -403,7 +408,9 @@ class FermaxStreamSession:
             signaling_url=signaling_url,
             oauth_token=oauth_token,
             fcm_token=fcm_token,
+            send_hangup=not receive_only,
         )
+        self._receive_only = receive_only
         self._room_id = room_id
         self._on_end = on_end
         self._media_root = media_root
@@ -618,14 +625,20 @@ class FermaxStreamSession:
 
             return str(our_producer_id)
 
-        # 6. Produce audio (48kHz like the APK) — triggers onProduce → pickup
-        self._switchable_track = _create_switchable_audio_track()
-        self._audio_producer = await self._send_transport.produce(
-            track=self._switchable_track,
-            stopTracks=False,
-            appData={},
-        )
-        _LOGGER.info("Audio producer started, pickup completed")
+        # 6. Produce audio (48kHz like the APK) — triggers onProduce → pickup.
+        # A receive-only session skips this: without pickup the call is never
+        # answered, so it keeps ringing while we watch the video (like the
+        # app's preview screen before attending).
+        if self._receive_only:
+            _LOGGER.info("Receive-only session, skipping pickup")
+        else:
+            self._switchable_track = _create_switchable_audio_track()
+            self._audio_producer = await self._send_transport.produce(
+                track=self._switchable_track,
+                stopTracks=False,
+                appData={},
+            )
+            _LOGGER.info("Audio producer started, pickup completed")
 
         # 8. Initialize recording (frames collected in _grab_frames)
         self._init_recording()

--- a/custom_components/fermax_blue/strings.json
+++ b/custom_components/fermax_blue/strings.json
@@ -146,6 +146,9 @@
       },
       "photo_caller": {
         "name": "Photo caller"
+      },
+      "ring_preview": {
+        "name": "Ring preview"
       }
     }
   }

--- a/custom_components/fermax_blue/switch.py
+++ b/custom_components/fermax_blue/switch.py
@@ -7,8 +7,10 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .coordinator import FermaxBlueCoordinator
@@ -31,6 +33,7 @@ async def async_setup_entry(
             entities.append(FermaxNotificationSwitch(coordinator))
         entities.append(FermaxDndSwitch(coordinator))
         entities.append(FermaxPhotoCallerSwitch(coordinator))
+        entities.append(FermaxRingPreviewSwitch(coordinator))
 
     async_add_entities(entities)
 
@@ -65,6 +68,48 @@ class FermaxNotificationSwitch(FermaxBlueEntity, SwitchEntity):
             await self.coordinator.notification_listener.stop()
             self._is_on = False
             self.async_write_ha_state()
+
+
+class FermaxRingPreviewSwitch(FermaxBlueEntity, SwitchEntity, RestoreEntity):
+    """Switch for the receive-only live preview on doorbell ring.
+
+    Per-device, purely local (no Fermax API involved), and restored across
+    restarts. When on, a ring starts a receive-only stream so the camera
+    shows the current visitor; the call is never answered.
+    """
+
+    _attr_translation_key = "ring_preview"
+
+    def __init__(self, coordinator: FermaxBlueCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._device_id}_ring_preview"
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the previous setting when added to hass."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            self.coordinator.ring_preview = last_state.state == STATE_ON
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if ring preview is enabled."""
+        return self.coordinator.ring_preview
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable ring preview."""
+        self.coordinator.ring_preview = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable ring preview."""
+        self.coordinator.ring_preview = False
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Always available — a local setting, not device state."""
+        return True
 
 
 class FermaxDndSwitch(FermaxBlueEntity, SwitchEntity):

--- a/custom_components/fermax_blue/translations/ar.json
+++ b/custom_components/fermax_blue/translations/ar.json
@@ -146,6 +146,9 @@
       },
       "photo_caller": {
         "name": "صورة الزائر"
+      },
+      "ring_preview": {
+        "name": "معاينة الرنين"
       }
     }
   }

--- a/custom_components/fermax_blue/translations/de.json
+++ b/custom_components/fermax_blue/translations/de.json
@@ -146,6 +146,9 @@
       },
       "photo_caller": {
         "name": "Besucherfoto"
+      },
+      "ring_preview": {
+        "name": "Vorschau beim Klingeln"
       }
     }
   }

--- a/custom_components/fermax_blue/translations/en.json
+++ b/custom_components/fermax_blue/translations/en.json
@@ -146,6 +146,9 @@
       },
       "photo_caller": {
         "name": "Photo caller"
+      },
+      "ring_preview": {
+        "name": "Ring preview"
       }
     }
   }

--- a/custom_components/fermax_blue/translations/es.json
+++ b/custom_components/fermax_blue/translations/es.json
@@ -146,6 +146,9 @@
       },
       "photo_caller": {
         "name": "Foto de visitante"
+      },
+      "ring_preview": {
+        "name": "Vista previa al llamar"
       }
     }
   }

--- a/custom_components/fermax_blue/translations/fr.json
+++ b/custom_components/fermax_blue/translations/fr.json
@@ -146,6 +146,9 @@
       },
       "photo_caller": {
         "name": "Photo visiteur"
+      },
+      "ring_preview": {
+        "name": "Aperçu à la sonnerie"
       }
     }
   }

--- a/custom_components/fermax_blue/translations/it.json
+++ b/custom_components/fermax_blue/translations/it.json
@@ -146,6 +146,9 @@
       },
       "photo_caller": {
         "name": "Foto visitatore"
+      },
+      "ring_preview": {
+        "name": "Anteprima alla chiamata"
       }
     }
   }

--- a/custom_components/fermax_blue/translations/nl.json
+++ b/custom_components/fermax_blue/translations/nl.json
@@ -146,6 +146,9 @@
       },
       "photo_caller": {
         "name": "Bezoeker foto"
+      },
+      "ring_preview": {
+        "name": "Voorbeeld bij aanbellen"
       }
     }
   }

--- a/custom_components/fermax_blue/translations/pl.json
+++ b/custom_components/fermax_blue/translations/pl.json
@@ -146,6 +146,9 @@
       },
       "photo_caller": {
         "name": "Zdjęcie odwiedzającego"
+      },
+      "ring_preview": {
+        "name": "Podgląd przy dzwonku"
       }
     }
   }

--- a/custom_components/fermax_blue/translations/pt.json
+++ b/custom_components/fermax_blue/translations/pt.json
@@ -146,6 +146,9 @@
       },
       "photo_caller": {
         "name": "Foto do visitante"
+      },
+      "ring_preview": {
+        "name": "Pré-visualização ao tocar"
       }
     }
   }

--- a/custom_components/fermax_blue/translations/tr.json
+++ b/custom_components/fermax_blue/translations/tr.json
@@ -146,6 +146,9 @@
       },
       "photo_caller": {
         "name": "Ziyaretçi fotoğrafı"
+      },
+      "ring_preview": {
+        "name": "Zil önizlemesi"
       }
     }
   }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,6 +10,7 @@ from custom_components.fermax_blue.api import (
     FermaxBlueApi,
     Pairing,
 )
+from custom_components.fermax_blue.const import CALL_MODE_NOTIFY, CALL_MODE_RECORD
 from custom_components.fermax_blue.coordinator import (
     FermaxBlueCoordinator,
     _is_trusted_signaling_url,
@@ -90,6 +91,9 @@ def coordinator(mock_hass, mock_api, pairing):
         coord._camera_active = False
         coord._last_divert_response = None
         coord._photo_fetch_pending = False
+        coord._call_mode = CALL_MODE_NOTIFY
+        coord._auto_response_file = ""
+        coord._ring_preview = False
         coord._doorbell_reset_unsub = None
         coord._camera_timeout_unsub = None
         coord._dnd_enabled = None
@@ -227,6 +231,57 @@ class TestCoordinatorPhotoCaller:
         await coordinator.set_photo_caller(True)
         mock_api.set_photo_caller.assert_called_once_with("dev1", enabled=True)
         assert coordinator.device_info.photocaller is True
+
+
+class TestRingPreview:
+    """The ring preview option starts a receive-only stream without answering."""
+
+    def _ring(self, coordinator, persistent_id="n1"):
+        notification = {
+            "data": {
+                "FermaxNotificationType": "Call",
+                "RoomId": "room1",
+                "SocketUrl": "https://signaling-pro-duoxme.fermax.io",
+                "FermaxToken": "ftok",
+            }
+        }
+        with (
+            patch("custom_components.fermax_blue.coordinator.async_dispatcher_send"),
+            patch(
+                "custom_components.fermax_blue.coordinator.async_call_later",
+                return_value=MagicMock(),
+            ),
+        ):
+            coordinator._handle_notification(notification, persistent_id)
+
+    def test_ring_starts_receive_only_stream(self, coordinator):
+        coordinator.hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+        coordinator._ring_preview = True
+        coordinator._start_stream = MagicMock()
+
+        self._ring(coordinator)
+
+        coordinator._start_stream.assert_called_once_with(
+            "room1", "https://signaling-pro-duoxme.fermax.io", "ftok", receive_only=True
+        )
+
+    def test_no_stream_in_notify_mode_by_default(self, coordinator):
+        coordinator.hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+        coordinator._start_stream = MagicMock()
+
+        self._ring(coordinator)
+
+        coordinator._start_stream.assert_not_called()
+
+    def test_attending_call_mode_still_picks_up(self, coordinator):
+        coordinator.hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+        coordinator._ring_preview = True
+        coordinator._call_mode = CALL_MODE_RECORD
+        coordinator._start_stream = MagicMock()
+
+        self._ring(coordinator)
+
+        assert coordinator._start_stream.call_args.kwargs["receive_only"] is False
 
 
 class TestCoordinatorScanInterval:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -243,6 +243,7 @@ class TestRingPreview:
                 "RoomId": "room1",
                 "SocketUrl": "https://signaling-pro-duoxme.fermax.io",
                 "FermaxToken": "ftok",
+                "PreviewTimeout": "29",
             }
         }
         with (
@@ -262,7 +263,11 @@ class TestRingPreview:
         self._ring(coordinator)
 
         coordinator._start_stream.assert_called_once_with(
-            "room1", "https://signaling-pro-duoxme.fermax.io", "ftok", receive_only=True
+            "room1",
+            "https://signaling-pro-duoxme.fermax.io",
+            "ftok",
+            receive_only=True,
+            preview_timeout="29",
         )
 
     def test_no_stream_in_notify_mode_by_default(self, coordinator):
@@ -282,6 +287,116 @@ class TestRingPreview:
         self._ring(coordinator)
 
         assert coordinator._start_stream.call_args.kwargs["receive_only"] is False
+
+
+class TestPreviewTimeoutClamp:
+    """Receive-only sessions honour the server-side PreviewTimeout ceiling."""
+
+    async def _start(self, coordinator, *, receive_only, preview_timeout, stream_duration):
+        coordinator._stream_session = None
+        coordinator._stream_stop_unsub = None
+        coordinator._stream_duration = stream_duration
+        listener = MagicMock()
+        listener.fcm_token = "tok"
+        coordinator.notification_listener = listener
+        session = MagicMock()
+        session.start = AsyncMock(return_value=True)
+        with (
+            patch(
+                "custom_components.fermax_blue.coordinator.streaming_deps_available",
+                return_value=True,
+            ),
+            patch(
+                "custom_components.fermax_blue.coordinator.FermaxStreamSession",
+                return_value=session,
+            ),
+            patch("custom_components.fermax_blue.coordinator.async_dispatcher_send"),
+            patch(
+                "custom_components.fermax_blue.coordinator.async_call_later",
+                return_value=MagicMock(),
+            ) as call_later,
+        ):
+            await coordinator._start_stream(
+                "room1",
+                "https://signaling-pro-duoxme.fermax.io",
+                "ftok",
+                receive_only=receive_only,
+                preview_timeout=preview_timeout,
+            )
+        return call_later.call_args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_clamped_to_payload_timeout(self, coordinator):
+        delay = await self._start(
+            coordinator, receive_only=True, preview_timeout="29", stream_duration=120
+        )
+        assert delay == 29
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_29_when_absent(self, coordinator):
+        delay = await self._start(
+            coordinator, receive_only=True, preview_timeout=None, stream_duration=60
+        )
+        assert delay == 29
+
+    @pytest.mark.asyncio
+    async def test_shorter_stream_duration_wins(self, coordinator):
+        delay = await self._start(
+            coordinator, receive_only=True, preview_timeout="60", stream_duration=15
+        )
+        assert delay == 15
+
+    @pytest.mark.asyncio
+    async def test_invalid_timeout_falls_back(self, coordinator):
+        delay = await self._start(
+            coordinator, receive_only=True, preview_timeout="garbage", stream_duration=120
+        )
+        assert delay == 29
+
+    @pytest.mark.asyncio
+    async def test_attended_stream_not_clamped(self, coordinator):
+        delay = await self._start(
+            coordinator, receive_only=False, preview_timeout="29", stream_duration=120
+        )
+        assert delay == 120
+
+
+class TestOpenDoorFallback:
+    """In-call door opening falls back to the standard endpoint on failure."""
+
+    def _active_session(self, coordinator):
+        session = MagicMock()
+        session.is_active = True
+        session._room_id = "room1"
+        coordinator._stream_session = session
+
+    @pytest.mark.asyncio
+    async def test_incall_endpoint_used_during_stream(self, coordinator, mock_api):
+        self._active_session(coordinator)
+        mock_api.open_door_incall = AsyncMock(return_value=True)
+        with patch("custom_components.fermax_blue.coordinator.async_dispatcher_send"):
+            assert await coordinator.open_door() is True
+        mock_api.open_door.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_incall_fails(self, coordinator, mock_api):
+        self._active_session(coordinator)
+        mock_api.open_door_incall = AsyncMock(return_value=False)
+        mock_api.open_door = AsyncMock(return_value=True)
+        with patch("custom_components.fermax_blue.coordinator.async_dispatcher_send"):
+            assert await coordinator.open_door() is True
+        mock_api.open_door_incall.assert_awaited_once()
+        mock_api.open_door.assert_awaited_once_with(
+            "dev1", {"block": 100, "subblock": -1, "number": 0}
+        )
+
+    @pytest.mark.asyncio
+    async def test_standard_endpoint_without_stream(self, coordinator, mock_api):
+        coordinator._stream_session = None
+        mock_api.open_door = AsyncMock(return_value=True)
+        with patch("custom_components.fermax_blue.coordinator.async_dispatcher_send"):
+            assert await coordinator.open_door() is True
+        mock_api.open_door_incall.assert_not_called()
 
 
 class TestCoordinatorScanInterval:

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -146,6 +146,99 @@ class TestPhotoCallerSwitch:
         mock_coordinator.set_photo_caller.assert_called_once_with(False)
 
 
+class TestRingPreviewSwitch:
+    """Test the ring preview switch and its restore behavior."""
+
+    def test_ring_preview_unique_id(self, mock_coordinator):
+        from custom_components.fermax_blue.switch import FermaxRingPreviewSwitch
+
+        switch = FermaxRingPreviewSwitch(mock_coordinator)
+        assert switch.unique_id == "test_dev_ring_preview"
+
+    @pytest.mark.asyncio
+    async def test_ring_preview_turn_on_off(self, mock_coordinator):
+        from custom_components.fermax_blue.switch import FermaxRingPreviewSwitch
+
+        switch = FermaxRingPreviewSwitch(mock_coordinator)
+        switch.async_write_ha_state = MagicMock()
+
+        await switch.async_turn_on()
+        assert mock_coordinator.ring_preview is True
+        await switch.async_turn_off()
+        assert mock_coordinator.ring_preview is False
+
+    @pytest.mark.asyncio
+    async def test_ring_preview_restores_last_state(self, mock_coordinator):
+        from homeassistant.core import State
+
+        from custom_components.fermax_blue.switch import FermaxRingPreviewSwitch
+
+        switch = FermaxRingPreviewSwitch(mock_coordinator)
+        switch.async_get_last_state = AsyncMock(return_value=State("switch.t", "on"))
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+            AsyncMock(),
+        ):
+            await switch.async_added_to_hass()
+
+        assert mock_coordinator.ring_preview is True
+
+
+class TestRestoredControls:
+    """Stream duration and call mode keep their prior state across restarts."""
+
+    @pytest.mark.asyncio
+    async def test_stream_duration_restored(self, mock_coordinator):
+        from custom_components.fermax_blue.number import FermaxStreamDurationNumber
+
+        number = FermaxStreamDurationNumber(mock_coordinator)
+        number.async_get_last_number_data = AsyncMock(return_value=MagicMock(native_value=60.0))
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+            AsyncMock(),
+        ):
+            await number.async_added_to_hass()
+
+        assert mock_coordinator.stream_duration == 60
+
+    @pytest.mark.asyncio
+    async def test_call_mode_restored(self, mock_coordinator):
+        from homeassistant.core import State
+
+        from custom_components.fermax_blue.select import FermaxCallModeSelect
+
+        select = FermaxCallModeSelect(mock_coordinator)
+        select.async_get_last_state = AsyncMock(return_value=State("select.t", "record"))
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+            AsyncMock(),
+        ):
+            await select.async_added_to_hass()
+
+        assert mock_coordinator.call_mode == "record"
+
+    @pytest.mark.asyncio
+    async def test_call_mode_ignores_invalid_state(self, mock_coordinator):
+        from homeassistant.core import State
+
+        from custom_components.fermax_blue.select import FermaxCallModeSelect
+
+        mock_coordinator.call_mode = "notify_only"
+        select = FermaxCallModeSelect(mock_coordinator)
+        select.async_get_last_state = AsyncMock(return_value=State("select.t", "unavailable"))
+
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+            AsyncMock(),
+        ):
+            await select.async_added_to_hass()
+
+        assert mock_coordinator.call_mode == "notify_only"
+
+
 class TestF1Button:
     """Test F1 auxiliary button."""
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,8 +1,16 @@
 """Tests for the streaming module."""
 
-from unittest.mock import patch
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from custom_components.fermax_blue.streaming import streaming_deps_available
+from custom_components.fermax_blue.streaming import (
+    ConsumeResult,
+    FermaxSignalingClient,
+    FermaxStreamSession,
+    RoomJoinResult,
+    TransportData,
+    streaming_deps_available,
+)
 
 
 class TestStreamingDepsAvailable:
@@ -21,3 +29,137 @@ class TestStreamingDepsAvailable:
         ):
             assert streaming_deps_available() is False
         streaming_deps_available.cache_clear()
+
+
+def _mock_transport() -> MagicMock:
+    transport = MagicMock()
+    transport.on = MagicMock(return_value=lambda f: f)
+    transport.close = AsyncMock()
+    return transport
+
+
+def _mocked_session(tmp_path, receive_only):
+    """Build a session with the signaling client and mediasoup device mocked out."""
+    session = FermaxStreamSession(
+        signaling_url="https://signaling-pro-duoxme.fermax.io",
+        oauth_token="oauth",
+        fcm_token="fcm",
+        room_id="room1",
+        media_root=str(tmp_path),
+        receive_only=receive_only,
+    )
+
+    transport_data = TransportData(
+        id="t1", dtls_parameters="{}", ice_candidates="[]", ice_parameters="{}"
+    )
+    signaling = MagicMock()
+    signaling.connect = AsyncMock(
+        return_value=RoomJoinResult(
+            video_producer_id="vp",
+            audio_producer_id="ap",
+            router_rtp_capabilities="{}",
+            recv_video_transport=transport_data,
+            recv_audio_transport=transport_data,
+            send_transport=transport_data,
+        )
+    )
+    signaling.consume_transport = AsyncMock(
+        return_value=ConsumeResult(
+            consumer_id="c1", producer_id="vp", kind="video", rtp_parameters=MagicMock()
+        )
+    )
+    signaling.connect_transport = AsyncMock(return_value=True)
+    signaling.pickup = AsyncMock()
+    signaling.disconnect = AsyncMock()
+    session._signaling = signaling
+
+    from aiortc.mediastreams import MediaStreamError
+
+    consumer = MagicMock()
+    consumer.track.recv = AsyncMock(side_effect=MediaStreamError)
+    consumer.close = AsyncMock()
+    recv_transport = _mock_transport()
+    recv_transport.consume = AsyncMock(return_value=consumer)
+
+    producer = MagicMock()
+    producer.close = AsyncMock()
+    send_transport = _mock_transport()
+    send_transport.produce = AsyncMock(return_value=producer)
+
+    device = MagicMock()
+    device.load = AsyncMock()
+    device.createRecvTransport = MagicMock(return_value=recv_transport)
+    device.createSendTransport = MagicMock(return_value=send_transport)
+    device.rtpCapabilities.dict = MagicMock(return_value={})
+
+    patches = (
+        patch("pymediasoup.Device", return_value=device),
+        patch("pymediasoup.rtp_parameters.RtpCapabilities", MagicMock()),
+        patch("pymediasoup.models.transport.DtlsParameters", MagicMock()),
+        patch("pymediasoup.models.transport.IceCandidate", MagicMock()),
+        patch("pymediasoup.models.transport.IceParameters", MagicMock()),
+    )
+    return session, send_transport, patches
+
+
+class TestReceiveOnlySession:
+    """Receive-only sessions consume video but never signal pickup."""
+
+    async def test_receive_only_skips_pickup(self, tmp_path):
+        session, send_transport, patches = _mocked_session(tmp_path, receive_only=True)
+
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            assert await session.start() is True
+
+        send_transport.produce.assert_not_awaited()
+        session._signaling.pickup.assert_not_awaited()
+        assert session._audio_producer is None
+        await session.stop()
+
+    async def test_normal_session_produces_audio(self, tmp_path):
+        session, send_transport, patches = _mocked_session(tmp_path, receive_only=False)
+
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            assert await session.start() is True
+
+        send_transport.produce.assert_awaited_once()
+        await session.stop()
+
+    def test_receive_only_session_disables_hangup(self, tmp_path):
+        session = FermaxStreamSession(
+            signaling_url="https://signaling-pro-duoxme.fermax.io",
+            oauth_token="",
+            fcm_token="",
+            room_id="r1",
+            media_root=str(tmp_path),
+            receive_only=True,
+        )
+        assert session._signaling._send_hangup is False
+
+
+class TestSignalingHangup:
+    """Hangup is only sent for sessions that could have picked up."""
+
+    async def test_disconnect_hangs_up_by_default(self):
+        client = FermaxSignalingClient()
+        sio = AsyncMock()
+        client._sio = sio
+        client._connected = True
+
+        await client.disconnect()
+
+        sio.emit.assert_awaited_once_with("hang_up", {})
+
+    async def test_receive_only_disconnect_skips_hangup(self):
+        client = FermaxSignalingClient(send_hangup=False)
+        sio = AsyncMock()
+        client._sio = sio
+        client._connected = True
+
+        await client.disconnect()
+
+        sio.emit.assert_not_awaited()


### PR DESCRIPTION
## Description

Live video currently only shows on ring if call mode is set to `record` or `auto_respond`, both of which answer the call. This PR adds an opt-in preview mode that starts a receive-only stream on ring so the camera shows live video while the panel continues ringing. For my use-case, it enables HA's HomeKit bridge to send a notification with the live preview that plays immediately on click, mirroring Fermax's app's preview screen before attending.

### Changes

- The coordinator starts a receive-only session on `Call` notifications when the preview is enabled and the call mode would not already attend. `Autoon` and the attending modes behave as before.
- A receive-only `FermaxStreamSession` consumes video but skips the audio production step that signals `pickup`. The call stays unattended and keeps ringing. It also skips the `hang_up` emission on disconnect, since hanging up a still-ringing call would end it for the visitor and other monitors.
- Receive-only sessions respect the `PreviewTimeout` field in the push payload (29s when the field is missing or unparseable). The server tears down an unattended preview at that point regardless of the local `stream_duration` setting. The auto-stop timer is clamped to `min(stream_duration, PreviewTimeout)` with a code comment on the server-side ceiling.
- Opening a door while a session is active retries the standard open-door endpoint when the in-call endpoint fails.
- The preview toggle is per-device under Controls and persists across restarts via `RestoreEntity`. It defaults to off.
- Restarting HA silently reset `call_mode` and `stream_duration` to `notify_only`/30s because they lived only in coordinator memory. Both now restore their last values on startup. An installation running `auto_respond` keeps that mode across restarts.
- The README entry for the switch now covers the `notify_only` scope, the server-side cap, and the recording side effect (every ring leaves a snapshot without answering, subject to the recording retention setting).

## Tests

Coverage added for all changes: receive-only sessions skipping produce/pickup and disabling hangup while normal sessions still produce audio, the signaling client's hang_up emit on disconnect, the coordinator starting a receive-only stream on ring only when enabled and still attending in `record`/`auto_respond` modes, the switch restore round-trip, and restored stream duration and call mode including rejection of invalid restored states.

```sh
$ make check
docker run --rm -v /[...]/fermax-blue-hass:/app -w /app fermax-blue-dev sh -c "ruff check custom_components/ tests/ scripts/ && ruff format --check custom_components/ tests/ scripts/ && mypy custom_components/fermax_blue/ --ignore-missing-imports && vulture custom_components/fermax_blue/ .vulture_whitelist.py --min-confidence 80 && pytest tests/ -q --tb=short"
All checks passed!
34 files already formatted
Success: no issues found in 19 source files
........................................................................ [ 35%]
........................................................................ [ 70%]
...........................................................              [100%]
203 passed in 9.29s
```

### Tested On

- Fermax device model: VEO-XS WiFi
- Home Assistant version: 18.1
