### PR TITLE
chore(ci): test on Python 3.13 + 3.14, drop 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v7

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12
+ARG PYTHON_VERSION=3.13
 FROM python:${PYTHON_VERSION}-slim
 
 RUN apt-get update -qq && \
@@ -10,7 +10,7 @@ RUN pip install --no-cache-dir \
     pytest pytest-asyncio pytest-cov \
     httpx firebase-messaging homeassistant \
     "python-socketio[asyncio_client]>=5.12.0" \
-    "av==13.1.0" pymediasoup Pillow numpy PyTurboJPEG \
-    && pip install --no-cache-dir "aiodns==3.2.0" "pycares==4.4.0"
+    av pymediasoup Pillow numpy PyTurboJPEG \
+    && pip install --no-cache-dir aiodns pycares
 
 WORKDIR /app

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Fermax Blue",
-  "homeassistant": "2024.6.0",
+  "homeassistant": "2025.2.0",
   "render_readme": true,
   "content_in_root": false
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "fermax-blue-hass"
 version = "0.9.0"
 description = "Home Assistant integration for Fermax Blue intercoms"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 
 [project.optional-dependencies]
 dev = [
@@ -23,7 +23,7 @@ filterwarnings = [
 ]
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.13"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
@@ -31,7 +31,7 @@ check_untyped_defs = true
 ignore_missing_imports = true
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py313"
 line-length = 100
 
 [tool.ruff.lint]

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -23,7 +23,7 @@ echo -e "${YELLOW}════════════════════�
 echo -e "${YELLOW}  Pre-push CI replica (Dockerfile.dev)        ${NC}"
 echo -e "${YELLOW}══════════════════════════════════════════════${NC}"
 
-for PY in 3.12 3.13; do
+for PY in 3.13 3.14; do
     TAG="${DEV_IMG}:py${PY}"
     step "Building image Python ${PY}"
     docker build -q -t "$TAG" --build-arg PYTHON_VERSION="$PY" -f "$PROJECT_DIR/Dockerfile.dev" "$PROJECT_DIR" > /dev/null \
@@ -31,7 +31,7 @@ for PY in 3.12 3.13; do
 
     RUN="docker run --rm -v $PROJECT_DIR:/app -w /app $TAG"
 
-    if [ "$PY" = "3.12" ]; then
+    if [ "$PY" = "3.13" ]; then
         step "Lint (py${PY})"
         $RUN ruff check custom_components/ tests/ scripts/ \
             && pass "Lint" || fail "Lint"


### PR DESCRIPTION
## Why

Home Assistant 2026.7 runs on **Python 3.14**, which CI did not cover — the matrix was `3.12 + 3.13`. This surfaced in #46, where a user on HA 2026.7.4 hit a failure inside `firebase-messaging` under `/usr/local/lib/python3.14/`. We were shipping to a runtime we never tested.

## Changes

- **CI matrix** → `3.13 + 3.14` (dropping 3.12 keeps the usual two supported versions).
- **`requires-python` → `>=3.13`** and **HACS minimum → `2025.2.0`**. HA has required Python 3.13 since 2025.2, so the declared support window now matches what is actually tested. Previously we claimed HA 2024.6+ while testing a Python version no supported HA release uses.
- **Unpin `av` in `Dockerfile.dev`.** `av==13.1.0` has no 3.14 wheel and fails to build from source. That pin dated from the aiortc/av incompatibility that `aiortc` 1.15.0 resolved (see the streaming note in the README), so it is obsolete. `aiodns`/`pycares` pins relaxed for the same reason.
- `scripts/pre-push.sh` matrix updated to stay an exact CI replica.

> Note: if you have the pre-push hook installed, refresh it — it is a static copy:
> `cp scripts/pre-push.sh .git/hooks/pre-push`

## Verification

`make pre-push` (full CI replica, both versions):

```
▶ Building image Python 3.13   ✓
▶ Lint / Format / Type check   ✓
▶ Tests (py3.13)               189 passed
▶ Building image Python 3.14   ✓
▶ Tests (py3.14)               189 passed
  All checks passed — safe to push
```

No source changes were needed for 3.14 — the integration code is already compatible. The only 3.14 noise is a `DeprecationWarning` from the third-party `backoff` package (`asyncio.iscoroutinefunction`, removal slated for 3.16); nothing actionable on our side yet.

## Note on #46

This does **not** fix #46 on its own — it only means we would now catch 3.14-specific breakage in CI. The FCM registration failure there still needs separate investigation.