### PR TITLE
chore(ci): run the test suite weekly to catch dependency drift

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Dependency drift check. Dockerfile.dev installs its dependencies unpinned,
+  # so a scheduled rebuild resolves fresh versions and surfaces breakage that
+  # commit-triggered runs cannot see: a dependency dropping support for a Python
+  # version in the matrix, a transitive conflict, or a manifest.json requirement
+  # going stale. Without this, such drift only appears on the next unrelated PR.
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why not Dependabot

This started as "add Dependabot on `Dockerfile.dev` so pins don't go stale silently". I checked, and Dependabot cannot cover either gap here:

- **`RUN pip install av==13.1.0`** — no Dependabot ecosystem parses versions inside a `RUN` line. This is where the stale pin actually lived.
- **`FROM python:${PYTHON_VERSION}-slim`** — the `docker` ecosystem only reads `FROM`, and it does not resolve `ARG` substitution in it ([dependabot-core#2057](https://github.com/dependabot/dependabot-core/issues/2057), [#4597](https://github.com/dependabot/dependabot-core/issues/4597), both still open). The ARG is what wires the Python matrix, so it cannot be removed.

Adding `package-ecosystem: docker` would have been a no-op. The existing `pip` + `github-actions` config already covers what Dependabot can see.

## What actually closes the gap

`Dockerfile.dev` installs its dependencies **unpinned**, so which versions a build resolves depends on *when* it runs. Commit-triggered runs cannot see drift that happens while the repo is quiet — it surfaces on the next unrelated PR, as noise attributed to whatever change happened to come next.

A weekly rebuild resolves fresh versions and turns that into a dated signal on `main`.

This is not hypothetical. It would have caught **#34** ahead of users: `Dockerfile.dev` installs `pymediasoup`, which pulls `aiortc` → `av`. When HA 2026.7 moved to `av==17` and no `aiortc` release allowed it, a weekly run would have failed to build at that point. Instead the integration failed to load for everyone who upgraded HA, and we found out from a bug report.

## Changes

- `schedule: cron "0 6 * * 1"` (Mondays 06:00 UTC) on the existing Tests workflow — all six jobs, including both Python versions.
- `workflow_dispatch` so it can also be triggered on demand.

No job definitions changed. GitHub notifies on scheduled-run failures on the default branch, so a red Monday is the signal.

## Verification

YAML parses with the expected triggers and jobs intact:

```
triggers: ['push', 'pull_request', 'schedule', 'workflow_dispatch']
cron:     [{'cron': '0 6 * * 1'}]
jobs:     ['test', 'lint', 'type-check', 'dead-code', 'hassfest', 'validate']
```

The PR run itself exercises the unchanged `push`/`pull_request` path.