### PR TITLE
chore(release): v0.18.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.18.0-beta.1] - 2026-07-31
+
+### Added
+- **Live preview on ring, without answering the call** (#45) — a new per-device `switch.<name>_ring_preview` starts a receive-only video stream when the doorbell rings, so the camera shows the current visitor within a few seconds while the panel keeps ringing. The call is never answered and no audio is sent or received, mirroring the preview screen the official app shows before attending. Until now live video on ring required `record` or `auto_respond` call mode, both of which answer the call. The switch is **off by default** (no behavior change unless enabled) and only has an effect in `notify_only` mode. The stream stops after the configured stream duration, capped by the server-side preview limit carried in the push payload (~29 s) — a longer `stream_duration` would otherwise leave the entities reporting a live stream after the server had already torn it down. Note that, like any stream session, the preview is recorded to the media folder (subject to the retention setting) and updates the last visitor photo, so every ring leaves a snapshot without answering. Contributed by @kiosion.
+
+### Changed
+- **Stream duration and call mode now survive a restart** (#45) — both entities reset to their defaults on every Home Assistant restart; they now restore their last value via `RestoreEntity`, like the new ring preview switch.
+
+### Fixed
+- **Opening a door during an active stream falls back to the standard endpoint** (#45) — if the in-call endpoint (`POST /device/incall/opendoor`) fails, the open-door command now retries the regular endpoint instead of reporting a failure, which matters on panel variants that behave differently during an unattended preview.
+
 ## [0.17.1] - 2026-07-18
 
 ### Fixed

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.5.0", "aiortc>=1.15.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.17.1"
+  "version": "0.18.0-beta.1"
 }


### PR DESCRIPTION
Prerelease for the opt-in ring preview feature contributed by @kiosion in #45.

- Manifest version → `0.18.0-beta.1` (minor bump: new feature)
- CHANGELOG entry covering:
  - **Added** — the `ring_preview` switch (receive-only stream on ring, off by default, `notify_only` only, clamped to the server-side ~29 s preview limit, with the recording/last-photo side-effect documented)
  - **Changed** — `stream_duration` and call mode now restore across restarts instead of resetting to defaults
  - **Fixed** — in-call door open falls back to the standard endpoint on failure

## Verification

`make pre-push` (full CI replica, both versions):

```
▶ Lint / Format / Type check   ✓
▶ Tests (py3.13)               211 passed
▶ Tests (py3.14)               211 passed
  All checks passed — safe to push
```

211 tests, up from 189 — #45 added 22 covering the receive-only session, the timeout clamp and the restored entities.

After merge: publish prerelease `v0.18.0-beta.1`, deploy + verify on the live HA (clean logs, new switch entity present, FCM listener stable), then promote to `v0.18.0` stable.