### PR TITLE
chore(release): v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.18.0-beta.1] - 2026-07-31
+## [0.18.0] - 2026-07-31
 
 ### Added
 - **Live preview on ring, without answering the call** (#45) — a new per-device `switch.<name>_ring_preview` starts a receive-only video stream when the doorbell rings, so the camera shows the current visitor within a few seconds while the panel keeps ringing. The call is never answered and no audio is sent or received, mirroring the preview screen the official app shows before attending. Until now live video on ring required `record` or `auto_respond` call mode, both of which answer the call. The switch is **off by default** (no behavior change unless enabled) and only has an effect in `notify_only` mode. The stream stops after the configured stream duration, capped by the server-side preview limit carried in the push payload (~29 s) — a longer `stream_duration` would otherwise leave the entities reporting a live stream after the server had already torn it down. Note that, like any stream session, the preview is recorded to the media folder (subject to the retention setting) and updates the last visitor photo, so every ring leaves a snapshot without answering. Contributed by @kiosion.

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.5.0", "aiortc>=1.15.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.18.0-beta.1"
+  "version": "0.18.0"
 }


### PR DESCRIPTION
Promotes the opt-in ring preview feature (#45, contributed by @kiosion) to stable.

- Manifest version → `0.18.0`
- CHANGELOG: the `[0.18.0-beta.1]` entry becomes `[0.18.0]` (no content change)

## Live verification of `v0.18.0-beta.1`

Deployed to Home Assistant 2026.7.4 (Supervised), restarted, boot completed in 132 s.

**Confirmed live:**
- Integration sets up clean — persisted camera frame loaded, FCM notification listener started, all 10 platforms set up. **No ERROR, WARNING or traceback from `fermax_blue`** (the only warnings in the window come from unrelated integrations: `xiaomi_miot` deprecations, a `tesla_custom` blocking call, `zha` unit mismatches, a `google_assistant` homegraph 404).
- The new entity is created and defaults to off: `switch.casa_videoportero_badalona_vista_previa_al_llamar` = `off`, recorded at 00:41:54.
- The existing 24 `fermax_blue` entities are unchanged; no entity was orphaned or duplicated.

**Not exercised live, covered by tests only:**
- The receive-only stream on ring — it needs a physical press of the street panel with the switch enabled, so it could not be triggered unattended.
- The restore-across-restart change: the live values (`stream_duration` = 30, call mode = `notify_only`) are identical to the defaults, so a restore is indistinguishable from a reset on this install. The behaviour is covered by the tests added in #45.

`make pre-push`: 211 tests passing on Python 3.13 and 3.14, lint/format/type-check/dead-code clean.