### PR TITLE
feat(camera): stamp still previews with a SNAPSHOT badge

### DIFF
--- a/custom_components/fermax_blue/coordinator.py
+++ b/custom_components/fermax_blue/coordinator.py
@@ -144,6 +144,43 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
         """Return the last captured photo."""
         return self._last_photo
 
+    @staticmethod
+    def _overlay_snapshot_indicator(jpeg: bytes | None) -> bytes | None:
+        """Burn a blue "SNAPSHOT HH:MM:SS" badge into a preview photo.
+
+        Counterpart of the red LIVE badge in streaming.py - it lets the user
+        tell a frozen still preview apart from a live stream. Recordings and
+        call photos saved to /media stay clean; only the camera preview frame
+        shown by the camera entity is stamped.
+        """
+        if not jpeg:
+            return jpeg
+        try:
+            import io
+            from datetime import datetime
+
+            from PIL import Image, ImageDraw, ImageFont
+
+            img = Image.open(io.BytesIO(jpeg)).convert("RGB")
+            draw = ImageDraw.Draw(img)
+            now = datetime.now().strftime("%H:%M:%S")
+            font = ImageFont.load_default(size=16)
+
+            # Blue "SNAPSHOT" badge top-left (the LIVE badge is red); the dot
+            # is drawn as an ellipse because the default PIL font has no glyph
+            # for U+25CF, and the badge width is sized to the rendered text
+            text = f"SNAPSHOT {now}"
+            text_w = draw.textlength(text, font=font)
+            draw.rectangle([(6, 6), (26 + text_w + 8, 28)], fill=(20, 80, 180))
+            draw.ellipse([(12, 12), (22, 22)], fill=(255, 255, 255))
+            draw.text((26, 7), text, fill=(255, 255, 255), font=font)
+
+            buf = io.BytesIO()
+            img.save(buf, format="JPEG", quality=75)
+            return buf.getvalue()
+        except Exception:
+            return jpeg  # Never let overlay failure lose the photo
+
     def _last_frame_path(self) -> Path | None:
         """Return the path for persisting the last camera frame."""
         if self._storage_path:
@@ -249,7 +286,9 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
                         if latest.photo_id and latest.photo_id != self._last_photo_id:
                             photo = await self.api.get_call_photo(latest.photo_id)
                             if photo:
-                                self._last_photo = photo
+                                # Badge only the preview; the call photo saved
+                                # to /media stays clean
+                                self._last_photo = self._overlay_snapshot_indicator(photo)
                                 self._last_photo_id = latest.photo_id
                                 self.hass.async_create_task(self._save_call_photo(photo))
             except Exception:
@@ -588,7 +627,9 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
                 self._stream_stop_unsub = None
             # Save last frame as photo preview before releasing the session
             if self._stream_session and self._stream_session.latest_frame:
-                self._last_photo = self._stream_session.latest_frame
+                self._last_photo = self._overlay_snapshot_indicator(
+                    self._stream_session.latest_frame_raw
+                )
                 self.hass.async_create_task(self._save_last_photo())
             self._stream_session = None
             self._camera_active = False
@@ -654,7 +695,9 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
         if self._stream_session:
             # Save last frame before stopping (stop() may clear internal state)
             if self._stream_session.latest_frame:
-                self._last_photo = self._stream_session.latest_frame
+                self._last_photo = self._overlay_snapshot_indicator(
+                    self._stream_session.latest_frame_raw
+                )
                 self.hass.async_create_task(self._save_last_photo())
             await self._stream_session.stop()
             self._stream_session = None

--- a/custom_components/fermax_blue/coordinator.py
+++ b/custom_components/fermax_blue/coordinator.py
@@ -176,7 +176,9 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
             draw.text((26, 7), text, fill=(255, 255, 255), font=font)
 
             buf = io.BytesIO()
-            img.save(buf, format="JPEG", quality=75)
+            # 90: this is a second lossy pass over an already-encoded JPEG;
+            # 75 left the preview visibly softer than the /media copy
+            img.save(buf, format="JPEG", quality=90)
             return buf.getvalue()
         except Exception:
             return jpeg  # Never let overlay failure lose the photo
@@ -187,11 +189,16 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
             return self._storage_path / f"last_frame_{self.pairing.device_id}.jpg"
         return None
 
-    async def _save_last_photo(self) -> None:
-        """Persist last photo to disk for survival across restarts."""
+    async def _save_last_photo(self, photo: bytes | None = None) -> None:
+        """Persist last photo to disk for survival across restarts.
+
+        Pass the raw (unbadged) frame explicitly: persisting the stamped
+        preview would resurrect a stale SNAPSHOT timestamp on the next start.
+        """
         path = self._last_frame_path()
-        if path and self._last_photo:
-            await asyncio.to_thread(path.write_bytes, self._last_photo)
+        data = photo if photo is not None else self._last_photo
+        if path and data:
+            await asyncio.to_thread(path.write_bytes, data)
 
     async def _save_call_photo(self, photo: bytes) -> None:
         """Save a doorbell call photo to the recordings directory."""
@@ -627,10 +634,9 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
                 self._stream_stop_unsub = None
             # Save last frame as photo preview before releasing the session
             if self._stream_session and self._stream_session.latest_frame:
-                self._last_photo = self._overlay_snapshot_indicator(
-                    self._stream_session.latest_frame_raw
-                )
-                self.hass.async_create_task(self._save_last_photo())
+                raw = self._stream_session.latest_frame_raw
+                self._last_photo = self._overlay_snapshot_indicator(raw)
+                self.hass.async_create_task(self._save_last_photo(raw))
             self._stream_session = None
             self._camera_active = False
             self.async_set_updated_data(self.data)
@@ -695,10 +701,9 @@ class FermaxBlueCoordinator(DataUpdateCoordinator):
         if self._stream_session:
             # Save last frame before stopping (stop() may clear internal state)
             if self._stream_session.latest_frame:
-                self._last_photo = self._overlay_snapshot_indicator(
-                    self._stream_session.latest_frame_raw
-                )
-                self.hass.async_create_task(self._save_last_photo())
+                raw = self._stream_session.latest_frame_raw
+                self._last_photo = self._overlay_snapshot_indicator(raw)
+                self.hass.async_create_task(self._save_last_photo(raw))
             await self._stream_session.stop()
             self._stream_session = None
             self._camera_active = False

--- a/custom_components/fermax_blue/streaming.py
+++ b/custom_components/fermax_blue/streaming.py
@@ -424,6 +424,7 @@ class FermaxStreamSession:
         self._recorder: Any = None
         self._frame_task: asyncio.Task | None = None
         self._latest_frame: bytes | None = None
+        self._last_raw_frame: bytes | None = None
         self._active = False
         self._room: Any = None
         self._recording_path: str | None = None
@@ -436,6 +437,11 @@ class FermaxStreamSession:
     def latest_frame(self) -> bytes | None:
         """Return the latest JPEG frame, or None if no frames yet."""
         return self._latest_frame
+
+    @property
+    def latest_frame_raw(self) -> bytes | None:
+        """Return the latest frame without the LIVE overlay (for still previews)."""
+        return self._last_raw_frame or self._latest_frame
 
     async def start(self) -> bool:
         """Start the full streaming pipeline."""
@@ -815,9 +821,14 @@ class FermaxStreamSession:
             now = datetime.now().strftime("%H:%M:%S")
             font = ImageFont.load_default(size=16)
 
-            # Red "● LIVE" badge top-left
-            draw.rectangle([(6, 6), (130, 28)], fill=(200, 0, 0))
-            draw.text((10, 7), f"\u25cf LIVE {now}", fill=(255, 255, 255), font=font)
+            # Red "LIVE" badge top-left; the dot is drawn as an ellipse
+            # because the default PIL font has no glyph for U+25CF, and the
+            # badge width is sized to the rendered text
+            text = f"LIVE {now}"
+            text_w = draw.textlength(text, font=font)
+            draw.rectangle([(6, 6), (26 + text_w + 8, 28)], fill=(200, 0, 0))
+            draw.ellipse([(12, 12), (22, 22)], fill=(255, 255, 255))
+            draw.text((26, 7), text, fill=(255, 255, 255), font=font)
         except Exception:
             pass  # Never let overlay failure break the stream
 
@@ -863,6 +874,9 @@ class FermaxStreamSession:
                 raw_jpeg = raw_buf.getvalue()
                 if hasattr(self, "_recording_frames") and self._recording_frames is not None:
                     self._recording_frames.append(raw_jpeg)
+                # Keep the overlay-free frame so still previews after the
+                # stream ends don't show a stale "LIVE" badge (see stop())
+                self._last_raw_frame = raw_jpeg
 
                 # Add LIVE overlay for display
                 img = self._overlay_live_indicator(img)
@@ -938,7 +952,10 @@ class FermaxStreamSession:
         # Give aiortc a moment to clean up internal tasks
         await asyncio.sleep(0.1)
 
-        # Keep _latest_frame for preview after stream ends
+        # Keep _latest_frame for preview after stream ends, but swap in the
+        # overlay-free version - a frozen "LIVE HH:MM:SS" badge is misleading
+        if self._last_raw_frame:
+            self._latest_frame = self._last_raw_frame
         _LOGGER.info("Stream session stopped")
 
     async def send_audio(self, audio_path: str) -> bool:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -482,3 +482,42 @@ class TestSnapshotOverlay:
     def test_invalid_jpeg_returned_unchanged(self):
         data = b"not a jpeg"
         assert FermaxBlueCoordinator._overlay_snapshot_indicator(data) == data
+
+
+class TestPersistedPreviewIsUnbadged:
+    """The frame persisted to .storage must be the raw, unstamped one.
+
+    Persisting the badged preview would resurrect a stale SNAPSHOT
+    timestamp after a restart via _load_last_photo().
+    """
+
+    @pytest.mark.asyncio
+    async def test_stop_stream_persists_raw_frame(self, coordinator):
+        raw = TestSnapshotOverlay._jpeg()
+        session = MagicMock()
+        session.latest_frame = b"badged-display-frame"
+        session.latest_frame_raw = raw
+        session.stop = AsyncMock()
+        coordinator._stream_session = session
+        coordinator._save_last_photo = MagicMock(return_value=None)
+        coordinator.hass.async_create_task = MagicMock()
+
+        await coordinator.stop_stream()
+
+        coordinator._save_last_photo.assert_called_once_with(raw)
+        # the in-memory preview still gets the badge
+        assert coordinator._last_photo != raw
+
+    @pytest.mark.asyncio
+    async def test_save_last_photo_prefers_explicit_photo(self, coordinator, tmp_path):
+        coordinator._storage_path = tmp_path
+        coordinator._last_photo = b"stamped"
+        await coordinator._save_last_photo(b"raw-bytes")
+        assert (tmp_path / "last_frame_dev1.jpg").read_bytes() == b"raw-bytes"
+
+    @pytest.mark.asyncio
+    async def test_save_last_photo_falls_back_to_last_photo(self, coordinator, tmp_path):
+        coordinator._storage_path = tmp_path
+        coordinator._last_photo = b"fallback"
+        await coordinator._save_last_photo()
+        assert (tmp_path / "last_frame_dev1.jpg").read_bytes() == b"fallback"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -447,3 +447,38 @@ class TestSignalingUrlValidation:
     )
     def test_untrusted_urls_rejected(self, url):
         assert _is_trusted_signaling_url(url) is False
+
+
+class TestSnapshotOverlay:
+    """The blue SNAPSHOT badge burned into still previews."""
+
+    @staticmethod
+    def _jpeg() -> bytes:
+        import io
+
+        from PIL import Image
+
+        buf = io.BytesIO()
+        Image.new("RGB", (368, 288), (0, 0, 0)).save(buf, format="JPEG")
+        return buf.getvalue()
+
+    def test_badge_is_burned_into_the_photo(self):
+        import io
+
+        from PIL import Image
+
+        out = FermaxBlueCoordinator._overlay_snapshot_indicator(self._jpeg())
+
+        img = Image.open(io.BytesIO(out))
+        # Blue badge background, white dot (JPEG is lossy, so approximate)
+        r, g, b = img.getpixel((8, 8))
+        assert b > 100 and b > r
+        r, g, b = img.getpixel((17, 17))
+        assert min(r, g, b) > 180
+
+    def test_none_passthrough(self):
+        assert FermaxBlueCoordinator._overlay_snapshot_indicator(None) is None
+
+    def test_invalid_jpeg_returned_unchanged(self):
+        data = b"not a jpeg"
+        assert FermaxBlueCoordinator._overlay_snapshot_indicator(data) == data

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -472,7 +472,8 @@ class TestSnapshotOverlay:
         img = Image.open(io.BytesIO(out))
         # Blue badge background, white dot (JPEG is lossy, so approximate)
         r, g, b = img.getpixel((8, 8))
-        assert b > 100 and b > r
+        assert b > 100
+        assert b > r
         r, g, b = img.getpixel((17, 17))
         assert min(r, g, b) > 180
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -163,3 +163,38 @@ class TestSignalingHangup:
         await client.disconnect()
 
         sio.emit.assert_not_awaited()
+
+
+class TestPreviewFrames:
+    """LIVE overlay rendering and the overlay-free preview frame."""
+
+    def _session(self) -> FermaxStreamSession:
+        return FermaxStreamSession(
+            signaling_url="https://signaling-pro-duoxme.fermax.io",
+            oauth_token="oauth",
+            fcm_token="fcm",
+            room_id="room1",
+        )
+
+    def test_overlay_live_indicator_draws_badge(self):
+        from PIL import Image
+
+        img = Image.new("RGB", (368, 288), (0, 0, 0))
+        out = FermaxStreamSession._overlay_live_indicator(img)
+
+        # Red badge background with the white dot drawn as an ellipse
+        assert out.getpixel((8, 8)) == (200, 0, 0)
+        assert out.getpixel((17, 17)) == (255, 255, 255)
+
+    def test_latest_frame_raw_prefers_overlay_free_frame(self):
+        session = self._session()
+        session._latest_frame = b"with-overlay"
+        session._last_raw_frame = b"raw"
+
+        assert session.latest_frame_raw == b"raw"
+
+    def test_latest_frame_raw_falls_back_to_latest_frame(self):
+        session = self._session()
+        session._latest_frame = b"with-overlay"
+
+        assert session.latest_frame_raw == b"with-overlay"


### PR DESCRIPTION
## What

Two related improvements to the burned-in camera badges:

1. **`fix(streaming)`: render the LIVE badge dot and size the badge to its text.** The default PIL font has no glyph for U+25CF, so the dot rendered as a placeholder box; it is now drawn with `ImageDraw.ellipse`. The badge rectangle was also a fixed 130px wide, which did not fit the rendered text — it is now sized with `draw.textlength()`.

2. **`feat(camera)`: stamp still previews with a blue SNAPSHOT badge.** After a stream ended, the camera entity kept showing the last live frame with its burned-in "LIVE HH:MM:SS" badge, so a frozen preview was indistinguishable from a live stream. The frame grabber now also keeps an overlay-free copy of the latest frame (`latest_frame_raw`), and the coordinator stamps still previews — the post-stream frame and the doorbell call photo — with a blue "SNAPSHOT HH:MM:SS" badge instead. Recordings and call photos saved to `/media` stay clean.

## Why

On a wall tablet / TV notification it was impossible to tell whether the displayed frame was live or a stale preview — the frozen frame still said "LIVE" with an old timestamp. The badge dot also rendered as a tofu box.

## Testing

- Unit tests added for the LIVE badge rendering, `latest_frame_raw` fallback behaviour, and the SNAPSHOT overlay (badge pixels, `None` passthrough, invalid-JPEG passthrough).
- Verified on a live install (VEO-XS WIFI, HA 2026.7): live stream shows the red LIVE badge with a proper dot, post-stream preview and ring photos show the blue SNAPSHOT badge, recordings in `/media` stay clean.

<img width="652" height="365" alt="live" src="https://github.com/user-attachments/assets/c55a13de-9965-454f-bd98-13fa7b22c116" />
<img width="635" height="352" alt="snapshot" src="https://github.com/user-attachments/assets/b0aa7699-95cb-4902-a885-74d0a8eaacc2" />
