### PR TITLE
feat(scripts): read OAuth credentials from BuildConfig on APK 4.3.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,15 +102,22 @@ The script reliably finds: `firebase_api_key`, `firebase_sender_id`, `firebase_a
 
 ##### OAuth client credentials (fermax_auth_basic)
 
-The OAuth `client_id` and `client_secret` are encrypted in the Android app and combined by `OAuthUtils.getAuthorizationHeader()` into the `Basic` auth header used for login. When a decompiled JADX directory is available, `scripts/extract_credentials.py` prefers this source:
+The OAuth `client_id` and `client_secret` are combined into the `Basic` auth header used for login. Where the app keeps them **depends on the APK version**, and `scripts/extract_credentials.py` handles both layouts when a decompiled JADX directory is available:
 
-- `com.fermax.blue.app.core.utils.OAuthUtils.getAuthorizationHeader()`
+**APK 4.3.0 and earlier — AES-encrypted byte arrays:**
+
+- `com.fermax.blue.app.core.utils.OAuthUtils.getAuthorizationHeader()` (holds the AES key)
 - `com.fermax.blue.app.data.remoteconfig.Urls.clientId()`
 - `com.fermax.blue.app.data.remoteconfig.Urls.clientSecret()`
 
-The production values should match the production URLs `oauth-pro-duoxme.fermax.io` and `pro-duoxme.fermax.io`.
+**APK 4.3.4 and later — plain string constants:**
 
-Do not use unrelated `Basic` headers from tracing or observability code. In particular, `TraceManagerOtelImpl.java` and `/monitoring/v1/traces` refer to telemetry, not OAuth login, and those headers will cause OAuth `invalid_client` errors.
+- `BuildConfig.OAUTH_CLIENT_ID`
+- `BuildConfig.OAUTH_CLIENT_SECRET`
+
+The encrypted layout is preferred when both are present. The production values should match the production URLs `oauth-pro-duoxme.fermax.io` and `pro-duoxme.fermax.io`.
+
+Do not use unrelated `Basic` headers from tracing or observability code. In particular, `TraceManagerOtelImpl.java`, `/monitoring/v1/traces` and the **`BuildConfig.TRACING_BASIC_AUTH`** constant refer to telemetry, not OAuth login, and those headers will cause OAuth `invalid_client` errors. `TRACING_BASIC_AUTH` is especially easy to confuse because it sits in the same `BuildConfig.java` as the OAuth constants; the script skips values assigned to telemetry-named constants for exactly this reason.
 
 Never publish `credentials.json`, generated `Basic` headers, Firebase keys, access tokens, refresh tokens, usernames, or passwords.
 
@@ -128,7 +135,7 @@ This integration exists thanks to the reverse-engineering work of these develope
 If the script doesn't find all values, decompile the APK with JADX and search manually:
 
 1. **API URLs**: search for `oauth/token` and `fermax.io` in `Urls.java`
-2. **OAuth Basic header**: inspect `OAuthUtils.getAuthorizationHeader()` and `Urls.clientId()` / `Urls.clientSecret()`. Select the production environment that corresponds to `oauth-pro-duoxme.fermax.io` / `pro-duoxme.fermax.io`, decrypt the encrypted byte arrays from those methods, URL-encode both values, join them as `client_id:client_secret`, then base64 encode that string and prefix it with `Basic `. Ignore telemetry headers from `TraceManagerOtelImpl.java`.
+2. **OAuth Basic header**: on APK 4.3.4+, read `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` straight from `BuildConfig.java` — they are stored in plain text. On APK 4.3.0 and earlier, inspect `OAuthUtils.getAuthorizationHeader()` and `Urls.clientId()` / `Urls.clientSecret()`, select the production environment that corresponds to `oauth-pro-duoxme.fermax.io` / `pro-duoxme.fermax.io`, and decrypt the encrypted byte arrays from those methods. Either way, URL-encode both values, join them as `client_id:client_secret`, then base64 encode that string and prefix it with `Basic `. Ignore telemetry headers from `TraceManagerOtelImpl.java` and the `TRACING_BASIC_AUTH` constant.
 3. **Firebase**: found in `google-services.json` inside the APK:
    - `firebase_api_key` → `client[0].api_key[0].current_key`
    - `firebase_sender_id` → `project_info.project_number`
@@ -322,7 +329,7 @@ automation:
 ### "Invalid credentials" error
 Make sure you're using the same email and password you use in the Fermax Blue mobile app. The password is case-sensitive.
 
-If Home Assistant logs show OAuth `invalid_client`, the problem is usually the OAuth client credentials (`fermax_auth_basic`), not your Fermax user email/password. Re-run the extraction against a JADX decompiled directory so the script can generate the header from `OAuthUtils.java` and `Urls.clientId()` / `Urls.clientSecret()`. Do not use `Basic` headers found near `TraceManagerOtelImpl.java`, `/monitoring/v1/traces`, OpenTelemetry, tracing, or observability code.
+If Home Assistant logs show OAuth `invalid_client`, the problem is usually the OAuth client credentials (`fermax_auth_basic`), not your Fermax user email/password. Re-run the extraction against a JADX decompiled directory so the script can generate the header from the real OAuth constants — `OAuthUtils.java` plus `Urls.clientId()` / `Urls.clientSecret()` on APK 4.3.0 and earlier, or `BuildConfig.OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` on 4.3.4 and later. Do not use `Basic` headers found near `TraceManagerOtelImpl.java`, `/monitoring/v1/traces`, OpenTelemetry, tracing, or observability code, nor the `TRACING_BASIC_AUTH` constant in `BuildConfig.java`.
 
 If logs show `invalid_grant` or Home Assistant reports `invalid_auth`, the problem is more likely the Fermax account credentials, account state, or an account without access to paired devices.
 

--- a/scripts/extract_credentials.py
+++ b/scripts/extract_credentials.py
@@ -27,15 +27,28 @@ BASIC_AUTH_RE = re.compile(r"(Basic\s+[A-Za-z0-9+/=]{50,})")
 PRODUCTION_AUTH_HOST = "oauth-pro-duoxme.fermax.io"
 PRODUCTION_BASE_HOST = "pro-duoxme.fermax.io"
 
+# Constants whose name marks them as telemetry credentials. The app ships a
+# TRACING_BASIC_AUTH header right next to the OAuth ones; picking it up as
+# fermax_auth_basic yields a Basic header the OAuth endpoint rejects.
+TRACING_CONSTANT_RE = re.compile(
+    r'\b[A-Z0-9_]*(?:TRACING|TRACE|MONITORING|OTEL|TELEMETRY)[A-Z0-9_]*\s*=\s*"([^"]{10,300})"'
+)
+
+# APK 4.3.4+ dropped the AES-encrypted arrays and stores the OAuth credentials
+# as plain string constants in BuildConfig instead.
+BUILD_CONFIG_CLIENT_ID_RE = re.compile(r'\bOAUTH_CLIENT_ID\s*=\s*"([^"]+)"')
+BUILD_CONFIG_CLIENT_SECRET_RE = re.compile(r'\bOAUTH_CLIENT_SECRET\s*=\s*"([^"]+)"')
+
 
 @dataclass(frozen=True)
 class OAuthCredentialCandidate:
-    """OAuth Basic candidate generated from encrypted APK OAuth credentials."""
+    """OAuth Basic candidate generated from APK OAuth credentials."""
 
     label: str
     auth_basic: str
     auth_url: str = ""
     base_url: str = ""
+    source: str = "OAuthUtils.java + Urls.java"
 
 
 def _has_monitoring_or_tracing_context(text: str) -> bool:
@@ -97,8 +110,11 @@ def _search_decompiled_dir(dir_path: str) -> list[str]:
         monitoring_context = _has_monitoring_or_tracing_context(
             f"{java_file.as_posix()}\n{content}"
         )
+        # Values assigned to a telemetry-named constant are never OAuth
+        # credentials, whatever file they live in (BuildConfig carries both).
+        tracing_values = set(TRACING_CONSTANT_RE.findall(content))
         for literal in re.findall(r'"([^"]{10,300})"', content):
-            if monitoring_context and BASIC_AUTH_RE.search(literal):
+            if BASIC_AUTH_RE.search(literal) and (monitoring_context or literal in tracing_values):
                 continue
             strings.append(literal)
 
@@ -310,11 +326,30 @@ def _select_oauth_candidate(
     return candidates[0] if len(candidates) == 1 else candidates[-1]
 
 
-def _extract_oauth_candidates_from_source(dir_path: str) -> list[OAuthCredentialCandidate]:
-    """Try to decrypt OAuth Basic candidates from OAuthUtils + Urls.java source."""
-    root = Path(dir_path)
+def _find_build_config_oauth(root: Path) -> tuple[str, str] | None:
+    """Find plaintext OAuth credentials in BuildConfig.java (APK 4.3.4+).
+
+    Library modules ship their own BuildConfig.java, so every match is checked
+    and only the one carrying both OAuth constants is used. The neighbouring
+    TRACING_BASIC_AUTH constant is deliberately never read.
+    """
+    for java_file in root.rglob("BuildConfig.java"):
+        try:
+            content = java_file.read_text(errors="ignore")
+        except OSError:
+            continue
+        client_id = BUILD_CONFIG_CLIENT_ID_RE.search(content)
+        client_secret = BUILD_CONFIG_CLIENT_SECRET_RE.search(content)
+        if client_id and client_secret:
+            return client_id.group(1), client_secret.group(1)
+    return None
+
+
+def _encrypted_oauth_candidates(
+    root: Path, content: str, auth_url: str, base_url: str
+) -> list[OAuthCredentialCandidate]:
+    """Decrypt the AES-encrypted OAuth arrays used up to APK 4.3.0."""
     aes_key = _find_oauth_aes_key(root)
-    content = _read_urls_source(root)
     if not aes_key or not content:
         return []
 
@@ -324,7 +359,6 @@ def _extract_oauth_candidates_from_source(dir_path: str) -> list[OAuthCredential
     if not candidate_count:
         return []
 
-    auth_url, base_url = _extract_preferred_urls_from_source(content)
     production_index = _production_candidate_index(content, auth_url, base_url, candidate_count)
 
     candidates: list[OAuthCredentialCandidate] = []
@@ -346,6 +380,36 @@ def _extract_oauth_candidates_from_source(dir_path: str) -> list[OAuthCredential
         )
 
     return candidates
+
+
+def _extract_oauth_candidates_from_source(dir_path: str) -> list[OAuthCredentialCandidate]:
+    """Build OAuth Basic candidates from decompiled source.
+
+    Prefers the encrypted OAuthUtils + Urls.java layout (APK <= 4.3.0) and
+    falls back to the plaintext BuildConfig constants introduced in 4.3.4.
+    """
+    root = Path(dir_path)
+    content = _read_urls_source(root)
+    auth_url, base_url = _extract_preferred_urls_from_source(content) if content else ("", "")
+
+    candidates = _encrypted_oauth_candidates(root, content, auth_url, base_url)
+    if candidates:
+        return candidates
+
+    plaintext = _find_build_config_oauth(root)
+    if not plaintext:
+        return []
+
+    client_id, client_secret = plaintext
+    return [
+        OAuthCredentialCandidate(
+            label="production",
+            auth_basic=_build_basic_header(client_id, client_secret),
+            auth_url=auth_url,
+            base_url=base_url,
+            source="BuildConfig.java",
+        )
+    ]
 
 
 def _extract_oauth_from_source(dir_path: str) -> str:
@@ -605,12 +669,12 @@ def main() -> None:
             decompiled_dir = str(possible)
 
     if decompiled_dir:
-        print("  Decrypting OAuth credentials from source...")
+        print("  Reading OAuth credentials from source...")
         oauth_candidates = _extract_oauth_candidates_from_source(decompiled_dir)
         oauth_candidate = _select_oauth_candidate(oauth_candidates)
         if oauth_candidate:
             creds["fermax_auth_basic"] = oauth_candidate.auth_basic
-            auth_basic_source = f"OAuthUtils.java + Urls.java ({oauth_candidate.label})"
+            auth_basic_source = f"{oauth_candidate.source} ({oauth_candidate.label})"
             if oauth_candidate.auth_url:
                 creds["fermax_auth_url"] = oauth_candidate.auth_url
             if oauth_candidate.base_url:
@@ -637,17 +701,20 @@ def main() -> None:
     # Warn about auth_basic source — the APK may contain non-OAuth Basic headers.
     if creds["fermax_auth_basic"]:
         print()
-        if auth_basic_source.startswith("OAuthUtils.java"):
-            print("  NOTE: fermax_auth_basic was generated from OAuthUtils.java and")
-            print("  Urls.java. Keep credentials.json private and never publish the")
-            print("  generated Basic header or Firebase values.")
+        if auth_basic_source and not auth_basic_source.startswith("generic"):
+            print(f"  NOTE: fermax_auth_basic was generated from {auth_basic_source}.")
+            print("  Keep credentials.json private and never publish the generated")
+            print("  Basic header or Firebase values.")
         else:
             print("  WARNING: fermax_auth_basic came from a generic string scan.")
             print("  APKs may contain unrelated Basic headers for tracing/monitoring")
-            print("  (for example TraceManagerOtelImpl / monitoring/v1/traces).")
+            print("  (for example TraceManagerOtelImpl / monitoring/v1/traces, or the")
+            print("  TRACING_BASIC_AUTH constant in BuildConfig).")
             print("  If authentication fails with 'invalid_client', decompile with")
-            print("  JADX and generate the OAuth header from OAuthUtils.java plus")
-            print("  Urls.clientId()/Urls.clientSecret() instead.")
+            print("  JADX and run this script against the output directory: it reads")
+            print("  OAuthUtils.java + Urls.clientId()/clientSecret() (APK <= 4.3.0)")
+            print("  or the OAUTH_CLIENT_ID/OAUTH_CLIENT_SECRET constants in")
+            print("  BuildConfig.java (APK 4.3.4+).")
 
     if found < total:
         missing = [k for k, v in creds.items() if not v]

--- a/tests/test_extract_credentials.py
+++ b/tests/test_extract_credentials.py
@@ -153,6 +153,37 @@ public final class Urls {{
     return tmp_path
 
 
+@pytest.fixture
+def fake_buildconfig_decompiled(tmp_path: Path) -> Path:
+    """Decompiled source in the 4.3.4 layout: plaintext OAuth constants in BuildConfig."""
+    app = tmp_path / "sources" / "com" / "fermax" / "blue" / "app"
+    remoteconfig = (
+        tmp_path / "sources" / "com" / "fermax" / "blue" / "app" / "data" / "remoteconfig"
+    )
+    app.mkdir(parents=True)
+    remoteconfig.mkdir(parents=True)
+
+    (app / "BuildConfig.java").write_text(
+        "public final class BuildConfig {\n"
+        "    public static final boolean DEBUG = false;\n"
+        '    public static final String APPLICATION_ID = "com.fermax.blue.app";\n'
+        '    public static final String BUILD_TYPE = "release";\n'
+        '    public static final String OAUTH_CLIENT_ID = "blue-app-prod";\n'
+        '    public static final String OAUTH_CLIENT_SECRET = "s3cr3t/value:x";\n'
+        '    public static final String TRACING_BASIC_AUTH = "Basic ' + "C" * 60 + '";\n'
+        '    public static final String VERSION_NAME = "4.3.4";\n'
+        "}\n"
+    )
+    (remoteconfig / "Urls.java").write_text(
+        "public final class Urls {\n"
+        '    public final String authUrl() { return "https://oauth-pro-duoxme.fermax.io"; }\n'
+        '    public final String baseUrl() { return "https://pro-duoxme.fermax.io"; }\n'
+        "}\n"
+    )
+
+    return tmp_path
+
+
 class TestExtractFromApk:
     """Test credential extraction from APK files."""
 
@@ -235,6 +266,112 @@ class TestExtractFromDecompiled:
         assert selected.auth_basic == expected_basic
         assert selected.auth_url == "https://oauth-pro-duoxme.fermax.io/oauth/token"
         assert selected.base_url == "https://pro-duoxme.fermax.io"
+
+
+class TestBuildConfigOAuth:
+    """OAuth credentials stored in plain text in BuildConfig (APK 4.3.4+)."""
+
+    def test_generates_oauth_basic_from_build_config(
+        self, script_module, fake_buildconfig_decompiled
+    ):
+        candidates = script_module._extract_oauth_candidates_from_source(
+            str(fake_buildconfig_decompiled)
+        )
+        selected = script_module._select_oauth_candidate(candidates)
+
+        expected_payload = f"{quote_plus('blue-app-prod')}:{quote_plus('s3cr3t/value:x')}"
+        expected_basic = "Basic " + base64.b64encode(expected_payload.encode()).decode()
+
+        assert selected is not None
+        assert selected.auth_basic == expected_basic
+        assert selected.source == "BuildConfig.java"
+
+    def test_urls_still_come_from_urls_source(self, script_module, fake_buildconfig_decompiled):
+        selected = script_module._select_oauth_candidate(
+            script_module._extract_oauth_candidates_from_source(str(fake_buildconfig_decompiled))
+        )
+
+        assert selected.auth_url == "https://oauth-pro-duoxme.fermax.io/oauth/token"
+        assert selected.base_url == "https://pro-duoxme.fermax.io"
+
+    def test_tracing_basic_auth_is_never_used_as_oauth(
+        self, script_module, fake_buildconfig_decompiled
+    ):
+        """The telemetry header sits next to the OAuth constants — it must not win."""
+        tracing_basic = "Basic " + "C" * 60
+
+        selected = script_module._select_oauth_candidate(
+            script_module._extract_oauth_candidates_from_source(str(fake_buildconfig_decompiled))
+        )
+        assert selected.auth_basic != tracing_basic
+
+        # ...and the generic literal scan must not surface it either
+        strings = script_module._search_decompiled_dir(str(fake_buildconfig_decompiled))
+        creds = script_module._find_credentials(strings)
+        assert creds["fermax_auth_basic"] == ""
+
+    def test_build_config_without_oauth_constants_is_ignored(self, script_module, tmp_path):
+        src = tmp_path / "sources" / "com" / "fermax" / "blue" / "app"
+        src.mkdir(parents=True)
+        (src / "BuildConfig.java").write_text(
+            "public final class BuildConfig {\n"
+            '    public static final String APPLICATION_ID = "com.fermax.blue.app";\n'
+            '    public static final String VERSION_NAME = "4.3.4";\n'
+            "}\n"
+        )
+
+        assert script_module._extract_oauth_candidates_from_source(str(tmp_path)) == []
+
+    def test_encrypted_layout_wins_when_both_are_present(
+        self, script_module, fake_oauth_decompiled
+    ):
+        """A 4.3.0-style APK keeps using the proven encrypted path."""
+        app = fake_oauth_decompiled / "sources" / "com" / "fermax" / "blue" / "app"
+        (app / "BuildConfig.java").write_text(
+            "public final class BuildConfig {\n"
+            '    public static final String OAUTH_CLIENT_ID = "decoy";\n'
+            '    public static final String OAUTH_CLIENT_SECRET = "decoy-secret";\n'
+            "}\n"
+        )
+
+        selected = script_module._select_oauth_candidate(
+            script_module._extract_oauth_candidates_from_source(str(fake_oauth_decompiled))
+        )
+
+        expected_payload = f"{quote_plus('prod client/id')}:{quote_plus('prod secret:with/slash')}"
+        assert (
+            selected.auth_basic == "Basic " + base64.b64encode(expected_payload.encode()).decode()
+        )
+        assert selected.source == "OAuthUtils.java + Urls.java"
+
+    def test_picks_the_build_config_carrying_the_oauth_constants(self, script_module, tmp_path):
+        """Library modules ship their own BuildConfig.java; only one has the credentials."""
+        base = tmp_path / "sources"
+        lib = base / "androidx" / "core"
+        app = base / "com" / "fermax" / "blue" / "app"
+        lib.mkdir(parents=True)
+        app.mkdir(parents=True)
+
+        (lib / "BuildConfig.java").write_text(
+            "public final class BuildConfig {\n"
+            '    public static final String LIBRARY_PACKAGE_NAME = "androidx.core";\n'
+            "}\n"
+        )
+        (app / "BuildConfig.java").write_text(
+            "public final class BuildConfig {\n"
+            '    public static final String OAUTH_CLIENT_ID = "real-id";\n'
+            '    public static final String OAUTH_CLIENT_SECRET = "real-secret";\n'
+            "}\n"
+        )
+
+        selected = script_module._select_oauth_candidate(
+            script_module._extract_oauth_candidates_from_source(str(tmp_path))
+        )
+
+        expected_payload = f"{quote_plus('real-id')}:{quote_plus('real-secret')}"
+        assert (
+            selected.auth_basic == "Basic " + base64.b64encode(expected_payload.encode()).decode()
+        )
 
 
 class TestGoogleServicesJson:


### PR DESCRIPTION
## Why

`scripts/extract_credentials.py` only understood the APK 4.3.0 credential layout: `client_id` / `client_secret` as AES-encrypted byte arrays in `Urls.java`, decrypted with the key from `OAuthUtils.java`.

**APK 4.3.4 changed that** — the arrays are gone and the credentials are plain string constants in `BuildConfig`:

```java
public static final String OAUTH_CLIENT_ID = "...";
public static final String OAUTH_CLIENT_SECRET = "...";
public static final String TRACING_BASIC_AUTH = "Basic ...";
```

On a 4.3.4 APK the extractor found no encrypted arrays and fell through to the generic string scan, which happily matched the **`TRACING_BASIC_AUTH`** header sitting three lines below the real credentials. The existing telemetry guard did not catch it: `_has_monitoring_or_tracing_context()` looks for hints like `opentelemetry`, `/monitoring/`, `/traces` or `tracemanagerotel`, and a `BuildConfig.java` contains none of them. The result is a plausible-looking `fermax_auth_basic` that the OAuth endpoint rejects with `invalid_client`.

This is the suspected cause of the reports in #33. It was never formally confirmed there (the reporter got working credentials another way), so the gap stayed open for the next person on a modern APK.

## Changes

- **`_find_build_config_oauth()`** — scans every `BuildConfig.java` (library modules ship their own) and uses the one carrying both OAuth constants, feeding the existing `_build_basic_header()`.
- **Layout precedence** — `_extract_oauth_candidates_from_source()` now tries the encrypted path first and falls back to BuildConfig, so 4.3.0 APKs keep using the proven route. Refactored the encrypted logic into `_encrypted_oauth_candidates()`; URL extraction moved up so `auth_url` / `base_url` still come from `Urls.java` under either layout.
- **Telemetry guard widened** — the generic scan now also skips any `Basic` literal assigned to a constant whose name contains `TRACING`, `TRACE`, `MONITORING`, `OTEL` or `TELEMETRY`, regardless of which file it lives in. This is the part that actually prevents the wrong header being picked.
- **`source` field on `OAuthCredentialCandidate`** — the CLI now reports where the header really came from instead of always claiming `OAuthUtils.java + Urls.java`.
- **README** — both layouts documented, in the OAuth section, the manual-extraction fallback and the `invalid_client` troubleshooting entry.

## Tests

TDD: 6 new tests, verified red before implementing.

- generates the correct Basic header from BuildConfig constants
- `auth_url` / `base_url` still resolved from `Urls.java`
- `TRACING_BASIC_AUTH` never wins — neither as a candidate nor through the generic scan
- a `BuildConfig.java` without OAuth constants is ignored
- the encrypted layout wins when both are present
- the right `BuildConfig.java` is picked when library modules ship their own

`make pre-push`: **217 tests** passing on Python 3.13 and 3.14 (211 before), lint/format/type-check/dead-code clean.

## Note on versioning

This only touches `scripts/` and the README — no integration runtime code — so there is no manifest bump here; it can ride along with the next release.

## Caveat

Verified against synthetic fixtures built from the layout in the #33 screenshots, not against a real 4.3.4 APK, which I do not have. The regex targets are simple constant assignments, so the risk is mainly that a future APK renames the constants rather than that the parsing is wrong.