### PR TITLE
chore(release): v0.19.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.19.0-beta.1] - 2026-08-07
+
+### Added
+- **Still previews are stamped with a SNAPSHOT badge** (#51) — after a stream ends, and when a doorbell ring fetches the visitor photo, the camera keeps showing a static frame; that preview now carries a `SNAPSHOT HH:MM:SS` badge so it is not mistaken for live video. Only the preview is stamped: the copies saved to `/media` and the frame persisted for restarts stay clean, so a preview restored after a Home Assistant restart never shows a stale timestamp from a previous session. Contributed by @RazorMeister.
+- **Credential extraction supports APK 4.3.4+** (#52) — newer app builds store the OAuth credentials as plaintext `BuildConfig` constants instead of the encrypted byte arrays of 4.3.0, so `scripts/extract_credentials.py` fell through to a generic scan that could pick up the telemetry `TRACING_BASIC_AUTH` header instead (the failure mode behind #33). The script now reads the `BuildConfig` constants directly and skips `Basic` literals assigned to tracing/monitoring constants.
+
+### Fixed
+- **LIVE badge no longer shows a placeholder box** (#51) — the recording indicator dot (`●`) has no glyph in the only font available inside the Home Assistant container, so the live overlay rendered a tofu box (`□`). The dot is now drawn as a shape, and the badge background is sized to its text instead of a fixed width. Contributed by @RazorMeister.
+
 ## [0.18.0] - 2026-07-31
 
 ### Added

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.5.0", "aiortc>=1.15.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.18.0"
+  "version": "0.19.0-beta.1"
 }


### PR DESCRIPTION
Prerelease cut for the SNAPSHOT badge (#51, @RazorMeister) and the APK 4.3.4+ credential extraction (#52).

- Manifest version 0.18.0 -> 0.19.0-beta.1
- CHANGELOG entry for 0.19.0-beta.1

Full local CI (3.13 + 3.14) green via pre-push hook. Will be published as a prerelease and verified on a live install before promotion to stable.