### PR TITLE
docs(readme): add release, tests, codeql, license and ruff badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Fermax Blue for Home Assistant
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
+[![GitHub Release](https://img.shields.io/github/release/bvis/fermax-blue-hass.svg)](https://github.com/bvis/fermax-blue-hass/releases)
+[![Tests](https://github.com/bvis/fermax-blue-hass/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/bvis/fermax-blue-hass/actions/workflows/tests.yml)
+[![CodeQL](https://github.com/bvis/fermax-blue-hass/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/bvis/fermax-blue-hass/actions/workflows/codeql.yml)
+[![License: MIT](https://img.shields.io/github/license/bvis/fermax-blue-hass.svg)](LICENSE)
+[![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 
 Home Assistant custom integration for **Fermax Blue** video door entry systems (DUOX PLUS / blueStream).
 


### PR DESCRIPTION
Adds the zero-config badge row, mirroring aegis-hass where it applies:

- **GitHub Release** — latest published version at a glance
- **Tests** — the existing `tests.yml` workflow (covers pytest 3.13/3.14, lint, type-check, dead-code, hassfest and HACS validation jobs)
- **CodeQL** — advanced-setup scanning already running on this repo
- **License: MIT** and **Code style: ruff**

No hassfest/HACS-specific badges: those run as jobs inside `tests.yml` and GitHub only exposes per-workflow badges — splitting workflows just for badges isn't worth the duplication.