### PR TITLE
ci: automate releases from tags and add daily secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,24 @@
+name: Secret scan
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Determine pre-release
+        id: prerelease
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if echo "$TAG_NAME" | grep -qE 'alpha|beta|rc|preview'; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract changelog for this version
+        id: changelog
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          # Pre-release sections carry the full version (`## [0.19.0-beta.1]`);
+          # on promotion the section is consolidated to the base version
+          # (`## [0.19.0]`). Try the exact version first, then the base.
+          BASE_VERSION="${VERSION%%-*}"
+          NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES=$(awk "/^## \[${BASE_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
+          fi
+          if [ -z "$NOTES" ]; then
+            NOTES="Release ${TAG_NAME}"
+          fi
+          {
+            echo "notes<<CHANGELOG_EOF"
+            echo "$NOTES"
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
+          body: ${{ steps.changelog.outputs.notes }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+# Gitleaks configuration for fermax-blue-hass.
+# Extends the built-in default ruleset and allowlists known non-secret
+# values so the scan stays low-noise. Real credentials live only in the
+# gitignored credentials.json and must never be committed.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known non-secrets and test fixtures"
+
+# Paths that only ever contain placeholders or synthesized values.
+paths = [
+  '''tests/.*''',
+  '''credentials\.example\.json''',
+]


### PR DESCRIPTION
Ports two workflows from aegis-hass, adapted to this repo:

**`release.yml`** — pushing a `v*` tag now creates the GitHub release automatically: notes extracted from the matching CHANGELOG section (exact version first — pre-release sections like `## [0.19.0-beta.1]` have their own heading here — then base-version fallback), `beta`/`rc`/`alpha` tags marked as prereleases. Replaces the manual `gh release create` step of the release flow.

**`gitleaks.yml` + `.gitleaks.toml`** — secret scan on push/PR plus a daily full-history scheduled scan. The allowlist covers `tests/` fixtures and `credentials.example.json` placeholders; real credentials only ever live in the gitignored `credentials.json`.

⚠️ This PR touches `.github/workflows/`, so it needs to be merged from the GitHub UI (the local token lacks the workflow scope for merges).