### PR TITLE
chore(release): v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.19.0-beta.1] - 2026-08-07
+## [0.19.0] - 2026-08-07
 
 ### Added
 - **Still previews are stamped with a SNAPSHOT badge** (#51) — after a stream ends, and when a doorbell ring fetches the visitor photo, the camera keeps showing a static frame; that preview now carries a `SNAPSHOT HH:MM:SS` badge so it is not mistaken for live video. Only the preview is stamped: the copies saved to `/media` and the frame persisted for restarts stay clean, so a preview restored after a Home Assistant restart never shows a stale timestamp from a previous session. Contributed by @RazorMeister.

--- a/custom_components/fermax_blue/manifest.json
+++ b/custom_components/fermax_blue/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bvis/fermax-blue-hass/issues",
   "requirements": ["httpx>=0.28.0", "firebase-messaging>=0.4.5", "python-socketio[asyncio_client]>=5.12.0", "pymediasoup>=1.5.0", "aiortc>=1.15.0", "Pillow>=10.0.0", "gTTS>=2.5.0"],
-  "version": "0.19.0-beta.1"
+  "version": "0.19.0"
 }


### PR DESCRIPTION
Promotes v0.19.0-beta.1 to stable. Beta verified end-to-end on a live install: LIVE badge dot renders correctly, post-stream preview carries the SNAPSHOT badge, the persisted frame stays raw, and the restored preview after a restart is byte-identical to the raw disk frame (no stale timestamp). Full stream, recording and FCM healthy, zero errors.

- Manifest 0.19.0-beta.1 -> 0.19.0
- CHANGELOG section consolidated to 0.19.0

Tagging `v0.19.0` after merge — first run of the new `release.yml` automation (#57).